### PR TITLE
Integrate CodeSniffer checks into TravisCI (task #799)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,5 @@ before_script:
 script:
   - ./vendor/bin/phpunit --group example
   - ./vendor/bin/phpunit --exclude-group example
+  - ./vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ config/ tests/Fixture/ tests/TestCase/
 


### PR DESCRIPTION
Enforcing CakePHP coding style on the following directories:

* src/ - application source code
* config/ - application configuration
* tests/Fixtures/, tests/TestCase - CakePHP related tests

The rest is skipped (especially in the testst/ folder), because
we are merging a lot from project-template, which does not
necessarily follow the same coding style.

The phpcs command and arguments were taken pretty much verbatim
from here:

https://github.com/FriendsOfCake/crud-view/blob/master/.travis.yml