### PR TITLE
Allow all from users plugin (task #1882)

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'Users.SimpleRbac.permissions' => [
+        [
+            'role' => '*',
+            'plugin' => '*',
+            'controller' => '*',
+            'action' => '*',
+        ],
+    ]];


### PR DESCRIPTION
- Allow all from users plugin permission. This allows [role-capabilities](https://github.com/QoboLtd/cakephp-roles-capabilities) to be only executed for access control.