### PR TITLE
Nginx fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ NGINX_SITE_MAIN=www.qobo.biz
 NGINX_SITE_OTHER=
 NGINX_ROOT_PREFIX=/var/www/html
 NGINX_LOG_PREFIX=/var/log/nginx
-NGINX_FASTCGI_PASS=127.0.0.1:9000;
+NGINX_FASTCGI_PASS=127.0.0.1:9000
 
 TEMPLATE_SRC=etc/nginx.conf.template
 TEMPLATE_DST=etc/nginx.conf


### PR DESCRIPTION
Removed an extra semicolon from `.env.example` file, which breaks Nginx template.