### PR TITLE
Load CsvMigrations plugin routes

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -181,7 +181,7 @@ Request::addDetector('tablet', function ($request) {
 
 Plugin::load('Migrations');
 Plugin::load('BootstrapUI');
-Plugin::load('CsvMigrations', ['bootstrap' => true]);
+Plugin::load('CsvMigrations', ['bootstrap' => true, 'routes' => true]);
 Plugin::load('Crud');
 Plugin::load('Groups', ['bootstrap' => false, 'routes' => true]);
 Plugin::load('RolesCapabilities', ['bootstrap' => true, 'routes' => true]);


### PR DESCRIPTION
This wasn't necessary until now as the plugin didn't have
any of its own functionality, but since the upgrade to
v4.0.0 it introduced Dblist field, which comes with its
own controllers.