### PR TITLE
Login form improvements (task #2476)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -54,6 +54,7 @@ class AppController extends Controller
         $this->loadComponent('CakeDC/Users.UsersAuth');
         $this->Auth->config('authorize', false);
         $this->Auth->config('loginRedirect', '/');
+        $this->Auth->config('flash', ['element' => 'error', 'key' => 'auth']);
         $this->loadComponent('RolesCapabilities.Capability', [
             'currentRequest' => $this->request->params
         ]);

--- a/src/Template/Layout/TwitterBootstrap/signin.ctp
+++ b/src/Template/Layout/TwitterBootstrap/signin.ctp
@@ -2,16 +2,6 @@
 $this->Html->css('BootstrapUI.signin', ['block' => true]);
 $this->prepend('tb_body_attrs', ' class="' . implode(' ', array($this->request->controller, $this->request->action)) . '" ');
 $this->start('tb_body_start');
-/**
- * Default `flash` block.
- */
-if (!$this->fetch('tb_flash')) {
-    $this->start('tb_flash');
-    if (isset($this->Flash))
-        echo $this->Flash->render();
-    $this->end();
-}
-?>
 <body <?= $this->fetch('tb_body_attrs') ?>>
     <div class="container">
 <?php

--- a/src/Template/Plugin/CakeDC/Users/Users/login.ctp
+++ b/src/Template/Plugin/CakeDC/Users/Users/login.ctp
@@ -50,7 +50,7 @@ $this->layout = 'QoboAdminPanel.plain';
                     </div>
                 </fieldset>
                 <?= implode(' ', $this->User->socialLoginList()); ?>
-                <?= $this->Form->button(__d('Users', 'Login')); ?>
+                <?= $this->Form->button(__d('Users', '<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> Login'), ['class' => 'btn btn-primary']); ?>
                 <?= $this->Form->end() ?>
             </div>
         </div>

--- a/src/Template/Plugin/CakeDC/Users/Users/login.ctp
+++ b/src/Template/Plugin/CakeDC/Users/Users/login.ctp
@@ -19,29 +19,35 @@ $this->layout = 'QoboAdminPanel.plain';
                 <fieldset>
                     <?= $this->Form->input('username', ['required' => true]) ?>
                     <?= $this->Form->input('password', ['required' => true]) ?>
-                    <?php
-                    if (Configure::check('Users.RememberMe.active')) {
-                        echo $this->Form->input(Configure::read('Users.Key.Data.rememberMe'), [
-                            'type' => 'checkbox',
-                            'label' => __d('Users', 'Remember me'),
-                            'checked' => 'checked'
-                        ]);
-                    }
-                    ?>
-                    <p>
-                        <?php
-                        $registrationActive = Configure::read('Users.Registration.active');
-                        if ($registrationActive) {
-                            echo $this->Html->link(__d('users', 'Register'), ['action' => 'register']);
-                        }
-                        if (Configure::read('Users.Email.required')) {
-                            if ($registrationActive) {
-                                echo ' | ';
+                    <div class="row">
+                        <div class="col-md-6">
+                            <?php
+                            if (Configure::check('Users.RememberMe.active')) {
+                                echo $this->Form->input(Configure::read('Users.Key.Data.rememberMe'), [
+                                    'type' => 'checkbox',
+                                    'label' => __d('Users', 'Remember me'),
+                                    'checked' => 'checked'
+                                ]);
                             }
-                            echo $this->Html->link(__d('users', 'Reset Password'), ['action' => 'requestResetPassword']);
-                        }
-                        ?>
-                    </p>
+                            ?>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="checkbox text-right">
+                                <?php
+                                $registrationActive = Configure::read('Users.Registration.active');
+                                if ($registrationActive) {
+                                    echo $this->Html->link(__d('users', 'Register'), ['action' => 'register']);
+                                }
+                                if (Configure::read('Users.Email.required')) {
+                                    if ($registrationActive) {
+                                        echo ' | ';
+                                    }
+                                    echo $this->Html->link(__d('users', 'Reset Password'), ['action' => 'requestResetPassword']);
+                                }
+                                ?>
+                            </div>
+                        </div>
+                    </div>
                 </fieldset>
                 <?= implode(' ', $this->User->socialLoginList()); ?>
                 <?= $this->Form->button(__d('Users', 'Login')); ?>

--- a/src/Template/Plugin/CakeDC/Users/Users/login.ctp
+++ b/src/Template/Plugin/CakeDC/Users/Users/login.ctp
@@ -16,6 +16,7 @@ $this->layout = 'QoboAdminPanel.plain';
                     ?>
                 </p>
                 <?= $this->Flash->render('auth') ?>
+                <?= $this->Flash->render() ?>
                 <fieldset>
                     <?= $this->Form->input('username', ['required' => true]) ?>
                     <?= $this->Form->input('password', ['required' => true]) ?>


### PR DESCRIPTION
The following adjustments were done to the login page:

* Move "Register | Reset Password" links to the right of "Remember Me" checkbox
* Login button styled as primary
* Login button given an icon
* Fixed missing styling on "You are not authorized to access this location" error message
* Fixed inconsistent location of "Username or password is incorrect" error message