### PR TITLE
Upgraded CsvMigrations to v5.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "qobo/cakephp-roles-capabilities": "~3.0",
         "friendsofcake/crud": "^4.3",
         "lorenzo/audit-stash": "^1.0",
-        "qobo/cakephp-csv-migrations": "^4.0",
+        "qobo/cakephp-csv-migrations": "^5.0",
         "qobo/cakephp-search": "^1.0",
         "alt3/cakephp-swagger": "^1.0"
     },


### PR DESCRIPTION
Upgraded to the [CsvMigrations v5.0.0](https://github.com/QoboLtd/cakephp-csv-migrations/releases/tag/v5+).  
Please backup your data before migrating.