### PR TITLE
TravisCI and Bitbucket Piplelines Validator fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ matrix:
 
 install:
     - ./bin/composer install --no-interaction --no-progress
+    - ./vendor/bin/phake dotenv:create CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_USER=root
     - ./bin/cake validate
-    - ./vendor/bin/phake app:install CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_USER=root
+    - ./vendor/bin/phake app:install
 
 before_script:
     - sh -e /etc/init.d/xvfb start

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -12,8 +12,9 @@ pipelines:
           - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           - chmod -R u+rwX,go-rwX ~/.ssh
           - ./bin/composer install --no-interaction --no-progress
+          - ./vendor/bin/phake dotenv:create CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_ADMIN_PASS=root DB_USER=root DB_PASS=root
           - ./bin/cake validate
-          - ./vendor/bin/phake app:install CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_ADMIN_PASS=root DB_USER=root DB_PASS=root
+          - ./vendor/bin/phake app:install
           - ./vendor/bin/phpunit --group example
           - ./vendor/bin/phpunit --exclude-group example
           - ./vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/Fixture/ tests/TestCase/


### PR DESCRIPTION
Validator should run before app:install so that it can check if
the configuration and migrations are good to go.  But for the
validator to run (as a CakePHP plugin shell), we need CakePHP
to be operational.  For that, we need the `.env` file to be in
place.

So, with this fix, we create the `.env` file prior to the attempt
to install the application (which will run the migrations, which
are possibly broken).  Once the `.env` file is in place, we can
run the validator, and if it passes, then we can run the phake's
`app:install` which will trigger migrations.