### PR TITLE
Fix for validate shell run in Travis/BitBucket Pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 install:
     - ./bin/composer install --no-interaction --no-progress --no-suggest
     - ./vendor/bin/phake dotenv:create CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_USER=root
-    - if [ -f "config/CsvMigrations" ] ; then ./bin/cake validate ; fi
+    - if [ -d "config/CsvMigrations" ] ; then ./bin/cake validate ; fi
     - ./vendor/bin/phake app:install
 
 before_script:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -13,7 +13,7 @@ pipelines:
           - chmod -R u+rwX,go-rwX ~/.ssh
           - ./bin/composer install --no-interaction --no-progress --no-suggest
           - ./vendor/bin/phake dotenv:create CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_ADMIN_PASS=root DB_USER=root DB_PASS=root
-          - if [ -f "config/CsvMigrations" ] ; then ./bin/cake validate ; fi
+          - if [ -d "config/CsvMigrations" ] ; then ./bin/cake validate ; fi
           - ./vendor/bin/phake app:install
           - ./vendor/bin/phpunit --group example
           - ./vendor/bin/phpunit --exclude-group example


### PR DESCRIPTION
Until now we were checking if **FILE** `config/CsvMigrations`
exists.  Which it doesn't. It's a **DIRECTORY**.