### PR TITLE
Keep debug level logs to file (task #807)

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -304,12 +304,14 @@ return [
      */
     'Log' => [
         'debug' => [
-            'className' => 'DatabaseLog.Database',
-            'levels' => ['notice', 'info', 'debug']
+            'className' => 'Cake\Log\Engine\FileLog',
+            'path' => LOGS,
+            'file' => 'debug',
+            'levels' => ['debug'],
         ],
         'error' => [
             'className' => 'DatabaseLog.Database',
-            'levels' => ['warning', 'error', 'critical', 'alert', 'emergency']
+            'levels' => ['notice', 'info', 'warning', 'error', 'critical', 'alert', 'emergency']
         ],
     ],
 


### PR DESCRIPTION
Logging debug level messages to the database is causing crashes because of recursive calls triggered by plugin loggers such as `DebugKit` and `CRUD`.