### PR TITLE
Added debug_kit database connection

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -331,6 +331,23 @@ return [
             'quoteIdentifiers' => true,
             //'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
         ],
+
+        /**
+         * SQLite connection for DebugKit plugin.  Even if the plugin
+         * is disabled, this is useful for when plugin migrations are
+         * running.
+         *
+         * Connection details are copied verbatim from the bootstrap.php
+         * file of the DebugKit plugin.
+         */
+        'debug_kit' => [
+            'className' => 'Cake\Database\Connection',
+            'driver' => 'Cake\Database\Driver\Sqlite',
+            'database' => TMP . 'debug_kit.sqlite',
+            'encoding' => 'utf8',
+            'cacheMetadata' => true,
+            'quoteIdentifiers' => false,
+        ],
     ],
 
     /**


### PR DESCRIPTION
DebugKit plugin defines its own database connection, which,
if you don't specify anything, uses Sqlite database in the tmp
folder.

Since DebugKit plugin is loaded conditionally, depending on the
value of the DEBUG variable, its configuration might not always
be loaded, and hence the connection is not defined.  Usually,
this works just fine, but in some cases, it breaks the process
of deployment, which runs migrations of all plugins.

To avoid the issue, debug_kit configurationw as copied verbatim
from DebugKit's bootstrap.php into the application's config/app.php
file.