### PR TITLE
Lock cakephp/migrations at version 1.6.3 (task #3135)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cakephp/cakephp": "~3.0",
         "cakephp/debug_kit": "~3.0",
         "mobiledetect/mobiledetectlib": "2.*",
-        "cakephp/migrations": "~1.0",
+        "cakephp/migrations": "1.6.3",
         "cakephp/plugin-installer": "*",
         "cakedc/users": "~3.1",
         "friendsofcake/bootstrap-ui": "~0.3",


### PR DESCRIPTION
cakephp/migrations 1.6.4 is not catching business logic exceptions
anymore, which breaks the deployment process sometimes.

This issue needs investigating and fixing, but for now, locking
migrations to the 1.6.3 should provide a temporary fix.