### PR TITLE
Session timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,7 @@ LDAP_ATTRIBUTES=givenName:first_name,sn:last_name,mail:email
 APP_SESSION_SECURE_COOKIE=0
 APP_SESSION_COOKIE_HTTP_ONLY=0
 APP_SESSION_USE_ONLY_COOKIES=1
-# Inactive session in minutes
+# Inactive session in seconds
 APP_SESSION_TIMEOUT=
 
 # iframe rendering header. Options are "DENY", "SAMEORIGIN" and "ALLOW-FROM https://example.com". Set to empty value to skip adding this header.

--- a/config/app.php
+++ b/config/app.php
@@ -419,11 +419,13 @@ return [
     'Session' => [
         'defaults' => 'php',
         'ini' => [
+            'session.use_only_cookies' => $useOnlyCookies,
             'session.cookie_secure' => $sessionCookieSecure,
             'session.cookie_httponly' => $cookieHttpOnly,
-            'session.use_only_cookies' => $useOnlyCookies,
+            'session.cookie_lifetime' => $sessionTimeout,
             'session.gc_maxlifetime' => $sessionTimeout,
-        ]
+        ],
+        'timeout' => (int)$sessionTimeout/60,
     ],
     'AuditStash' => [
         'persister' => 'App\Persister\MysqlPersister'


### PR DESCRIPTION
* Switch .env/.env.example APP_SESSION_TIMEOUT to seconds
* Make sure .env/.env.example setting is actually used
* Set cookie.lifetime to the same value as session timeout.  This
  should enforce server-side cookie lifetime, and not trust the
  user broser so much.
* Set Session.timeout to minutes equivalent of the PHP setting of
  session timeout.  PHP configuration and Session configuration can
  be read/used separately, so having them set to the same value is
  convenient.