### PR TITLE
Exclude 'config' directories from documentation

### DIFF
--- a/etc/sami/full.php
+++ b/etc/sami/full.php
@@ -28,6 +28,7 @@ catch (\Exception $e) {
 $iterator = Finder::create()
     ->files()
     ->name('*.php')
+    ->exclude('config')
     ->exclude('tests')
     ->exclude('Test')
     ->in(['./src', './vendor'])

--- a/etc/sami/source.php
+++ b/etc/sami/source.php
@@ -26,6 +26,7 @@ catch (\Exception $e) {
 $iterator = Finder::create()
     ->files()
     ->name('*.php')
+    ->exclude('config')
     ->exclude('tests')
     ->exclude('Test')
     ->in(['./src'])


### PR DESCRIPTION
CakePHP config directories, among other things, contain migration
files, which don't need to be part of the documentation.