### PR TITLE
Removing obsolete user fields in edit form

### DIFF
--- a/src/Template/Plugin/CakeDC/Users/Users/edit.ctp
+++ b/src/Template/Plugin/CakeDC/Users/Users/edit.ctp
@@ -26,25 +26,6 @@
                         </div>
                         <div class="row">
                             <div class="col-xs-12 col-md-6">
-                                <?= $this->Form->input('token'); ?>
-                            </div>
-                            <div class="col-xs-12 col-md-6">
-                                <?= $this->Form->input('token_expires'); ?>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-xs-12 col-md-6">
-                                <?= $this->Form->input('api_token'); ?>
-                            </div>
-                            <div class="col-xs-12 col-md-6">
-                                <?= $this->Form->input('activation_date'); ?>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-xs-12 col-md-6">
-                                <?= $this->Form->input('tos_date'); ?>
-                            </div>
-                            <div class="col-xs-12 col-md-6">
                                 <?= $this->Form->input('active'); ?>
                             </div>
                         </div>


### PR DESCRIPTION
We're not using following fields for the User managment.