### PR TITLE
Remember Me functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@ APP_SESSION_SECURE_COOKIE=0
 APP_SESSION_COOKIE_HTTP_ONLY=0
 APP_SESSION_USE_ONLY_COOKIES=1
 # Inactive session in seconds
-APP_SESSION_TIMEOUT=
+APP_SESSION_TIMEOUT=43200
 
 # iframe rendering header. Options are "DENY", "SAMEORIGIN" and "ALLOW-FROM https://example.com". Set to empty value to skip adding this header.
 ALLOW_IFRAME_RENDERING=DENY

--- a/config/users.php
+++ b/config/users.php
@@ -3,4 +3,17 @@
 return [
     'Users.table' => 'Users',
     'Users.GoogleAuthenticator.login' => false,
+    // disable remember-me functionality because currently it affects google authenticator functionality:
+    // https://github.com/CakeDC/users/issues/488
+    'Users.RememberMe.active' => false,
+    // this is a workaround for disabling RememberMe functionality bug:
+    // https://github.com/CakeDC/users/issues/490
+    'Auth.authenticate' => [
+        'all' => [
+            'finder' => 'auth',
+        ],
+        'CakeDC/Users.ApiKey',
+        // 'CakeDC/Users.RememberMe',
+        'Form',
+    ],
 ];


### PR DESCRIPTION
* Temporarily disabled remember-me functionality because currently, it affects GA functionality.
* Increased session timeout to 12 hours (overnight), since we have disabled remember-me functionality.