### PR TITLE
Headers expiry and request methods white-list

### DIFF
--- a/etc/nginx.conf.template
+++ b/etc/nginx.conf.template
@@ -26,10 +26,10 @@ server {
 	#
 
 	# Non-aggressive Expires header for JavaScript, CSS, and images
-	location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-		expires 5m;
-		log_not_found off;
-	}
+	#location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+	#	expires 5m;
+	#	log_not_found off;
+	#}
 
 	#
 	# Restrictions
@@ -50,9 +50,9 @@ server {
 	}
 
 	# Disable all methods besides HEAD, GET, and POST
-	if ($request_method !~ ^(GET|HEAD|POST)$) {
-			return 444;
-	}
+	#if ($request_method !~ ^(GET|HEAD|POST)$) {
+	#		return 444;
+	#}
 
 	# Do not hanndle Let's Encrypt validations
 	# Thanks to: http://stackoverflow.com/a/34262192/151647


### PR DESCRIPTION
Commented out header expiry and request method white-list lines from nginx config template, as it breaks assets management in CakePHP applications.