### PR TITLE
Fixed incorrect parameter in Schema task (task #3362)

### DIFF
--- a/src/Shell/Task/SchemaTask.php
+++ b/src/Shell/Task/SchemaTask.php
@@ -81,7 +81,7 @@ class SchemaTask extends Shell
             $defs = [];
             try {
                 $tableObject = TableRegistry::get($tableName);
-                $defs = $tableObject->getFieldsDefinitions($tableName);
+                $defs = $tableObject->getFieldsDefinitions();
             } catch (\Exception $e) {
                 // Skip non-CSV based table
             }


### PR DESCRIPTION
Schema task was incorrectly calling `getFieldsDefinitions()` method
from CsvMigrations plugin MigrationsTrait, passing it a table name.

This method signature was obsolete in one of the recent major versions
of the plugin, during the field handler refactoring.