### PR TITLE
Update plugin migration to run it separately

### DIFF
--- a/Phakefile.php
+++ b/Phakefile.php
@@ -188,9 +188,15 @@ group('cakephp', function () {
         doShellCommand($command, $secureStrings);
 
         // Run plugin migrations
-        printInfo("Testing plugin migrations");
-        $command = getenv('CAKE_CONSOLE') . ' plugin migrations migrate --connection=test';
-        doShellCommand($command);
+        printInfo("Testing ;plugin migrations");
+        $result = doShellCommand(getenv('CAKE_CONSOLE') . ' plugin loaded');
+        $result = preg_replace('/^.*\-\n/s', '', $result);
+        $loadedPlugins = (explode("\n", $result));
+        foreach ($loadedPlugins as $plugin) {
+            printInfo("Testing migration for plugin $plugin");
+            $command = getenv('CAKE_CONSOLE') . " migrations migrate -p $plugin --connection=test";
+            doShellCommand($command);
+        }
 
         // Run app migrations
         printInfo("Testing application migrations");

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -187,9 +187,10 @@ group('cakephp', function () {
         $secureStrings = ['DB_PASS', 'DB_ADMIN_PASS'];
         doShellCommand($command, $secureStrings);
 
-        // Run plugin migrations
+        // Run plugin migrations separately for each plugin
         printInfo("Testing ;plugin migrations");
-        $result = doShellCommand(getenv('CAKE_CONSOLE') . ' plugin loaded');
+        $command = getenv('CAKE_CONSOLE') . ' plugin loaded';
+        $result = doShellCommand($command);
         $result = preg_replace('/^.*\-\n/s', '', $result);
         $loadedPlugins = (explode("\n", $result));
         foreach ($loadedPlugins as $plugin) {
@@ -197,7 +198,6 @@ group('cakephp', function () {
             $command = getenv('CAKE_CONSOLE') . " migrations migrate -p $plugin --connection=test";
             doShellCommand($command);
         }
-
         // Run app migrations
         printInfo("Testing application migrations");
         $command = getenv('CAKE_CONSOLE') . ' migrations migrate --connection=test';
@@ -215,11 +215,17 @@ group('cakephp', function () {
         printSeparator();
         printInfo("Task: cakephp:migrations (Run CakePHP migrations task)");
 
-        // Run plugin migrations
+        // Run plugin migrations separately for each loaded plugin
         printInfo("Running plugin migrations");
-        $command = getenv('CAKE_CONSOLE') . ' plugin migrations migrate';
-        doShellCommand($command);
-
+        $command = getenv('CAKE_CONSOLE') . ' plugin loaded';
+        $result = doShellCommand($command);
+        $result = preg_replace('/^.*\-\n/s', '', $result);
+        $loadedPlugins = (explode("\n", $result));
+        foreach ($loadedPlugins as $plugin) {
+            printInfo("Testing migration for plugin $plugin");
+            $command = getenv('CAKE_CONSOLE') . " migrations migrate -p $plugin --connection=test";
+            doShellCommand($command);
+        }
         // Run app migrations
         printInfo("Running application migrations");
         $command = getenv('CAKE_CONSOLE') . ' migrations migrate';

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -188,7 +188,7 @@ group('cakephp', function () {
         doShellCommand($command, $secureStrings);
 
         // Run plugin migrations separately for each plugin
-        printInfo("Testing ;plugin migrations");
+        printInfo("Testing plugin migrations");
         $command = getenv('CAKE_CONSOLE') . ' plugin loaded';
         $result = doShellCommand($command);
         $result = preg_replace('/^.*\-\n/s', '', $result);

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -191,7 +191,6 @@ group('cakephp', function () {
         printInfo("Testing plugin migrations");
         $command = getenv('CAKE_CONSOLE') . ' plugin loaded';
         $result = doShellCommand($command);
-        $result = preg_replace('/^.*\-\n/s', '', $result);
         $loadedPlugins = (explode("\n", $result));
         foreach ($loadedPlugins as $plugin) {
             printInfo("Testing migration for plugin $plugin");
@@ -219,7 +218,6 @@ group('cakephp', function () {
         printInfo("Running plugin migrations");
         $command = getenv('CAKE_CONSOLE') . ' plugin loaded';
         $result = doShellCommand($command);
-        $result = preg_replace('/^.*\-\n/s', '', $result);
         $loadedPlugins = (explode("\n", $result));
         foreach ($loadedPlugins as $plugin) {
             printInfo("Testing migration for plugin $plugin");

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -223,7 +223,7 @@ group('cakephp', function () {
         $loadedPlugins = (explode("\n", $result));
         foreach ($loadedPlugins as $plugin) {
             printInfo("Testing migration for plugin $plugin");
-            $command = getenv('CAKE_CONSOLE') . " migrations migrate -p $plugin --connection=test";
+            $command = getenv('CAKE_CONSOLE') . " migrations migrate -p $plugin";
             doShellCommand($command);
         }
         // Run app migrations

--- a/src/Shell/PluginShell.php
+++ b/src/Shell/PluginShell.php
@@ -41,7 +41,7 @@ class PluginShell extends CorePluginShell
     /**
      *  No welcome message in the cake shell output
      *
-     *  @return void
+     * @return void
      */
     protected function _welcome()
     {

--- a/src/Shell/PluginShell.php
+++ b/src/Shell/PluginShell.php
@@ -37,4 +37,13 @@ class PluginShell extends CorePluginShell
 
         return $parser;
     }
+
+    /**
+     *  No welcome message in the cake shell output
+     *
+     *  @return void
+     */
+    protected function _welcome()
+    {
+    }
 }


### PR DESCRIPTION
Currently migration is run for all loaded plugins in one time. As result migrations files with the same class names cannot be used.