### PR TITLE
Moving migration dblist scheck to shell (task #3798)

### DIFF
--- a/Phakefile.php
+++ b/Phakefile.php
@@ -275,6 +275,7 @@ group('cakephp', function () {
             'role import',
             'capability assign',
             'menu import',
+            'check_dblist_permissions',
             'dblists_add',
         ];
 

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -275,7 +275,7 @@ group('cakephp', function () {
             'role import',
             'capability assign',
             'menu import',
-            'check_dblist_permissions',
+            'add_dblist_permissions',
             'dblists_add',
         ];
 

--- a/config/Migrations/20170510143029_AllowViewDblistsToEveryone.php
+++ b/config/Migrations/20170510143029_AllowViewDblistsToEveryone.php
@@ -1,8 +1,6 @@
 <?php
 use Migrations\AbstractMigration;
 
-use Cake\ORM\TableRegistry;
-
 class AllowViewDblistsToEveryone extends AbstractMigration
 {
     /**
@@ -14,39 +12,7 @@ class AllowViewDblistsToEveryone extends AbstractMigration
      */
     public function change()
     {
-        $roleId = null;
-        $targetRoleName = 'Everyone';
-
-        $capsToAdd = [
-            'cap__CsvMigrations_Controller_DblistsController__index',
-            'cap__CsvMigrations_Controller_DblistItemsController__index',
-        ];
-
-        $rolesTable = TableRegistry::get('RolesCapabilities.Roles');
-        $capTable = TableRegistry::get('RolesCapabilities.Capabilities');
-
-        $role = $rolesTable->find()
-            ->where(['name' => $targetRoleName])
-            ->first();
-
-        if (!empty($role)) {
-            foreach ($capsToAdd as $capability) {
-                $result = $capTable->find()
-                    ->where(
-                        [
-                            'name' => $capability,
-                            'role_id' => $role->id,
-                        ]
-                    )->first();
-
-                //save capability if it doesn't exist for 'everyone' role.
-                if (!$result) {
-                    $capEntity = $capTable->newEntity();
-                    $capEntity->name = $capability;
-                    $capEntity->role_id = $role->id;
-                    $capTable->save($capEntity);
-                }
-            }
-        }
+        //NOTE: code moved to src/Shell/CheckDblistPermissions.
+        //Migration left intentionally for backward-compatibility reasons.
     }
 }

--- a/src/Shell/AddDblistPermissionsShell.php
+++ b/src/Shell/AddDblistPermissionsShell.php
@@ -5,9 +5,9 @@ use Cake\Console\Shell;
 use Cake\ORM\TableRegistry;
 
 /**
- * CheckDblistPermissions shell command.
+ * AddDblistPermissions shell command.
  */
-class CheckDblistPermissionsShell extends Shell
+class AddDblistPermissionsShell extends Shell
 {
 
     /**

--- a/src/Shell/CheckDblistPermissionsShell.php
+++ b/src/Shell/CheckDblistPermissionsShell.php
@@ -1,0 +1,78 @@
+<?php
+namespace App\Shell;
+
+use Cake\Console\Shell;
+use Cake\ORM\TableRegistry;
+
+/**
+ * CheckDblistPermissions shell command.
+ */
+class CheckDblistPermissionsShell extends Shell
+{
+
+    /**
+     * Manage the available sub-commands along with their arguments and help
+     *
+     * @see http://book.cakephp.org/3.0/en/console-and-shells.html#configuring-options-and-generating-help
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        return $parser;
+    }
+
+    /**
+     * main() method.
+     *
+     * @return bool|int|null Success or error code.
+     */
+    public function main()
+    {
+        $this->out("Shell: Add Dblist 'list' capability to 'Everyone' role");
+        $this->hr();
+
+        $roleId = null;
+        $targetRoleName = 'Everyone';
+
+        $capsToAdd = [
+            'cap__CsvMigrations_Controller_DblistsController__index',
+            'cap__CsvMigrations_Controller_DblistItemsController__index',
+        ];
+
+        $rolesTable = TableRegistry::get('RolesCapabilities.Roles');
+        $capTable = TableRegistry::get('RolesCapabilities.Capabilities');
+
+        $role = $rolesTable->find()
+            ->where(['name' => $targetRoleName])
+            ->first();
+
+        if (!empty($role)) {
+            foreach ($capsToAdd as $capability) {
+                $result = $capTable->find()
+                    ->where(
+                        [
+                            'name' => $capability,
+                            'role_id' => $role->id,
+                        ]
+                    )->first();
+
+                //save capability if it doesn't exist for 'everyone' role.
+                if (!$result) {
+                    $capEntity = $capTable->newEntity();
+                    $capEntity->name = $capability;
+                    $capEntity->role_id = $role->id;
+                    if ($capTable->save($capEntity)) {
+                        $this->out("<info>Capability [$capability] added to role [{$role->name}]</info>");
+                    }
+                } else {
+                    $this->out("<info>Capability [$capability] for role [{$role->name}] already exists.</info>");
+                }
+            }
+        }
+
+        $this->out("<success>Roles adding completed.</success>");
+    }
+}


### PR DESCRIPTION
To have more control over permissions checks, Migration script
is moved to the shell so we can call it whenever we need.