### PR TITLE
Added MagicDefaultValueListener (task #3567)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -39,6 +39,7 @@ if (!extension_loaded('intl')) {
 }
 
 use App\Event\Component\UserIdentifyListener;
+use App\Event\MagicDefaultValueListener;
 use App\Event\Menu\MenuListener;
 use App\Event\Model\SearchableFieldsListener;
 use App\Event\Model\SearchResultsListener;
@@ -240,6 +241,7 @@ DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');
 
 EventManager::instance()->on(new UserIdentifyListener());
+EventManager::instance()->on(new MagicDefaultValueListener());
 EventManager::instance()->on(new MenuListener());
 EventManager::instance()->on(new SearchableFieldsListener());
 EventManager::instance()->on(new SearchResultsListener());

--- a/src/Event/MagicDefaultValueListener.php
+++ b/src/Event/MagicDefaultValueListener.php
@@ -1,0 +1,127 @@
+<?php
+namespace App\Event;
+
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\Utility\Inflector;
+
+class MagicDefaultValueListener implements EventListenerInterface
+{
+    /**
+     * @return array of implemented Events
+     */
+    public function implementedEvents()
+    {
+        return [
+            'CsvMigrations.FieldHandler.DefaultValue' => 'getDefaultValue',
+        ];
+    }
+
+    /**
+     * Provide magic default value
+     *
+     * Convert a default value in magic form like %CURRENT_DATE%
+     * to a dynamic value like '2017-06-27'.
+     *
+     * @param \Cake\Event\Event $event Event instance
+     * @param string $default Default value (before conversion)
+     * @return mixed Converted value or previous default
+     */
+    public function getDefaultValue(Event $event, $default = null)
+    {
+        $result = $default;
+
+        // If default is not in a magic format (%MAGIC_EXAMPLE%)
+        // then return the default value as is
+        if (!preg_match('/^%(.+)%$/', $default, $matches)) {
+            return $result;
+        }
+
+        // Get field handler instance
+        $fieldHandler = $event->subject();
+
+        // Convert magic format to a method name.
+        // For example: MAGIC_EXAMPLE = getMagicExampleValue
+        $magicValue = strtolower($matches[1]);
+        $magicValue = Inflector::camelize($magicValue);
+        $magicValue = 'get' . $magicValue . 'Value';
+
+        // TODO: Add some logging here for non-supported magic values
+        if (method_exists($this, $magicValue) && is_callable([$this, $magicValue])) {
+            $result = $this->$magicValue($fieldHandler);
+        }
+
+        return $result;
+    }
+
+    /**
+     * CURRENT_DATE magic value
+     *
+     * @param $object $fieldHandler Field handler instance
+     * @return string
+     */
+    protected function getCurrentDateValue($fieldHandler = null)
+    {
+        return date('Y-m-d');
+    }
+
+    /**
+     * CURRENT_TIME magic value
+     *
+     * @param $object $fieldHandler Field handler instance
+     * @return string
+     */
+    protected function getCurrentTimeValue($fieldHandler = null)
+    {
+        return date('H:i:s');
+    }
+
+    /**
+     * CURRENT_DATETIME magic value
+     *
+     * @param $object $fieldHandler Field handler instance
+     * @return string
+     */
+    protected function getCurrentDatetimeValue($fieldHandler = null)
+    {
+        return date('Y-m-d H:i:s');
+    }
+
+    /**
+     * CURRENT_DATETIME magic value
+     *
+     * @param $object $fieldHandler Field handler instance
+     * @return string
+     */
+    protected function getCurrentUserIdValue($fieldHandler = null)
+    {
+        $result = null;
+
+        // No way to figure out user without fieldHandler
+        if (empty($fieldHandler) || !is_object($fieldHandler)) {
+            return $result;
+        }
+
+        // No way to figure out user without AppView instance
+        if (!property_exists($fieldHandler, 'cakeView') || empty($fieldHandler->cakeView)) {
+            return $result;
+        }
+
+        // No way to figure out user without view variables
+        if (!property_exists($fieldHandler->cakeView, 'viewVars')) {
+            return $result;
+        }
+
+        // No way to figure out user without user view variable
+        if (empty($fieldHandler->cakeView->viewVars['user'])) {
+            return $result;
+        }
+
+        // We are in luck if the user ID is set
+        if (!empty($fieldHandler->cakeView->viewVars['user']['id'])) {
+            $result = $fieldHandler->cakeView->viewVars['user']['id'];
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
This even listener, combined with the latest
CsvMigrations plugin, allows for dynamic values
as field defaults (which is magical).

For example, instead of the static defaults like

```
[field]
default=foobar
```

One now can set dynamic values like:

```
[field]
default=%CURRENT_DATE%
```

Supported dynamic defaults are:

* CURRENT_DATE
* CURRENT_TIME
* CURRENT_DATETIME
* CURRENT_USER_ID

More can be easily supported by adding protected methods
to the MagicDefaultValueListener, matching the naming
convention:

1. Convert default to lower case.
2. Convert from underscores to CamelCase.
3. Prefix with 'get'.
4. Suffix with 'Value'.

For example, `CURRENT_USER_ID` becomes `getCurrentUserIdValue()`.