### PR TITLE
Lock zircote/swagger-php to 2.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "qobo/cakephp-roles-capabilities": "^11.0",
         "qobo/cakephp-search": "^10.0",
         "qobo/cakephp-utils": "^4.0",
-        "qobo/phake-builder": "^3.0"
+        "qobo/phake-builder": "^3.0",
+        "zircote/swagger-php": "2.0.8"
     },
     "require-dev": {
         "cakephp/bake": "~1.0",


### PR DESCRIPTION
zircote/swagger, which is used by alt3/cakephp-swagger, dropped
support for PHP 5 in version 2.0.9.  Until we are ready to do the
same, we lock the version down.