### PR TITLE
Lock doctrine/annotations to v1.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "cakephp/migrations": "^1.6",
         "cakephp/plugin-installer": "*",
         "dereuromark/cakephp-databaselog": "^2.1",
+        "doctrine/annotations": "v1.4.0",
         "friendsofcake/bootstrap-ui": "~0.3",
         "friendsofcake/crud": "^4.3",
         "fzaninotto/faker": "^1.0",


### PR DESCRIPTION
doctrine/annotations, which is used by zircote/swagger, dropped
support for PHP 5 in version v1.5.0.  Until we are ready to do the
same, we lock the version down.