### PR TITLE
Lock doctrine/instantiator to 1.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "cakephp/plugin-installer": "*",
         "dereuromark/cakephp-databaselog": "^2.1",
         "doctrine/annotations": "v1.4.0",
+        "doctrine/instantiator": "1.0.5",
         "friendsofcake/bootstrap-ui": "~0.3",
         "friendsofcake/crud": "^4.3",
         "fzaninotto/faker": "^1.0",


### PR DESCRIPTION
doctrine/instantiator, which is used by phpspec/prophecy and
phpunit/phpunit-mock-objects, dropped support for PHP 5 in
version 1.1.0.  Until we are ready to do the same, we lock the
version down.