### PR TITLE
Fixed the display of the logs

### DIFF
--- a/src/Controller/LogsController.php
+++ b/src/Controller/LogsController.php
@@ -17,5 +17,6 @@ class LogsController extends BaseController
     {
         parent::initialize();
         $this->paginate['limit'] = 10;
+        $this->paginate['fields'] = null;
     }
 }


### PR DESCRIPTION
DatabaseLogs controller limits the fields that go to pagination.
This fix removes the field limitations, so that the result contains
all of them, which fixes our index view.