### PR TITLE
Adding live-search for users list (task #2676)

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -62,7 +62,7 @@ Router::scope('/', function ($routes) {
      */
     $routes->connect('/', ['plugin' => 'Search', 'controller' => 'Dashboards', 'action' => 'index']);
 
-    $routes->connect('/users/', ['plugin' => 'CakeDC/Users', 'controller' => 'Users', 'action' => 'index']);
+    $routes->connect('/users/', ['controller' => 'Users', 'action' => 'index']);
     $routes->connect('/users/change-user-password/*', ['controller' => 'Users', 'action' => 'changeUserPassword']);
     $routes->connect('/users/upload-image/*', ['controller' => 'Users', 'action' => 'uploadImage']);
     $routes->connect('/users/edit-profile/*', ['controller' => 'Users', 'action' => 'editProfile']);

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -153,4 +153,19 @@ class UsersController extends AppController
 
         return $this->redirect($this->request->referer());
     }
+
+    /**
+     * Index method
+     *
+     * @return void
+     */
+    public function index()
+    {
+        $table = $this->loadModel();
+        $tableAlias = $table->alias();
+        $users = $table->find()->all();
+        $this->set($tableAlias, $users);
+        $this->set('tableAlias', $tableAlias);
+        $this->set('_serialize', [$tableAlias, 'tableAlias']);
+    }
 }

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -1,0 +1,112 @@
+<?php
+use Cake\Core\Configure;
+use CsvMigrations\FieldHandlers\FieldHandlerFactory;
+
+$fhf = new FieldHandlerFactory($this);
+
+echo $this->Html->css('AdminLTE./plugins/datatables/dataTables.bootstrap', ['block' => 'css']);
+echo $this->Html->script(
+    [
+        'AdminLTE./plugins/datatables/jquery.dataTables.min',
+        'AdminLTE./plugins/datatables/dataTables.bootstrap.min'
+    ],
+    [
+        'block' => 'scriptBottom'
+    ]
+);
+
+echo $this->Html->scriptBlock(
+    '$(".table-datatable").DataTable({
+        stateSave:true,
+        paging:true,
+        searching:true
+    });',
+    ['block' => 'scriptBottom']
+);
+
+?>
+<section class="content-header">
+    <div class="row">
+        <div class="col-xs-12 col-md-6">
+            <h4><?= __('Users');?></h4>
+        </div>
+        <div class="col-xs-12 col-md-6">
+            <div class="pull-right">
+                <div class="btn-group btn-group-sm" role="group">
+                <?= $this->Html->link(
+                    '<i class="fa fa-plus"></i> ' . __('Add'),
+                    ['plugin' => 'CakeDC/Users', 'controller' => 'Users', 'action' => 'add'],
+                    ['escape' => false, 'title' => __('Add'), 'class' => 'btn btn-default']
+                ); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="content">
+    <div class="box box-solid">
+        <div class="box-body">
+            <table class="table table-hover table-condensed table-vertical-align table-datatable">
+                <thead>
+                    <tr>
+                <th><?= __('Username') ?></th>
+                <th><?= __('Email') ?></th>
+                <th><?= __('First Name') ?></th>
+                <th><?= __('Last Name') ?></th>
+                <th><?= __('Gender') ?></th>
+                <th><?= __('Birthdate') ?></th>
+                <th class="actions"><?= __d('Users', 'Actions') ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($Users as $user) : ?>
+                    <tr>
+                        <td><?= h($user->username) ?></td>
+                        <td><?= h($user->email) ?></td>
+                        <td><?= h($user->first_name) ?></td>
+                        <td><?= h($user->last_name) ?></td>
+                        <td><?php
+                            $definition = [
+                                'name' => 'gender',
+                                'type' => 'list(genders)',
+                                'required' => false
+                            ];
+                            echo $fhf->renderValue('Users', 'gender', $user, ['fieldDefinitions' => $definition]);
+                        ?></td>
+                        <td><?= $user->has('birthdate') ? $user->birthdate->i18nFormat('yyyy-MM-dd') : '' ?></td>
+                        <td class="actions">
+                            <div class="btn-group btn-group-xs" role="group">
+                            <?= $this->Html->link(
+                                '<i class="fa fa-eye"></i>',
+                                ['plugin' => 'CakeDC/Users', 'controller' => 'Users', 'action' => 'view', $user->id],
+                                ['title' => __('View'), 'class' => 'btn btn-default btn-sm', 'escape' => false]
+                            ); ?>
+                            <?= $this->Html->link(
+                                '<i class="fa fa-pencil"></i>',
+                                ['plugin' => 'CakeDC/Users', 'controller' => 'Users', 'action' => 'edit', $user->id],
+                                ['title' => __('Edit'), 'class' => 'btn btn-default btn-sm', 'escape' => false]
+                            ); ?>
+                            <?= $this->Html->link(
+                                '<i class="fa fa-lock"></i>',
+                                ['action' => 'change-user-password', $user->id],
+                                ['title' => __('Change User Password'), 'class' => 'btn btn-default btn-sm', 'escape' => false]
+                            ) ?>
+                            <?= $this->Form->postLink(
+                                '<i class="fa fa-trash"></i>',
+                                ['plugin' => 'CakeDC/Users', 'controller' => 'Users', 'action' => 'delete', $user->id],
+                                [
+                                    'confirm' => __('Are you sure you want to delete # {0}?', $user->id),
+                                    'title' => __('Delete'),
+                                    'class' => 'btn btn-default btn-sm',
+                                    'escape' => false
+                                ]
+                            ) ?>
+                            </div>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
As an intermediate solution to enable live-search we overwrite `cakedc/users::index()` method to replace CakePHP pagination with jQuery dataTables functionality.

  