### PR TITLE
AJAX template routing fixes

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -82,6 +82,9 @@ class AppController extends Controller
      */
     public function beforeRender(Event $event)
     {
+        if ($this->request->is('ajax')) {
+            $this->viewBuilder()->className('Json');
+        }
         $this->set('user', $this->Auth->user());
     }
 
@@ -129,9 +132,7 @@ class AppController extends Controller
         $this->_generateApiToken();
 
         // Use AdminLTE View instead of our App\View
-        if (!$this->request->is('ajax')) {
-            $this->viewBuilder()->className('AdminLTE.AdminLTE');
-        }
+        $this->viewBuilder()->className('AdminLTE.AdminLTE');
         $this->viewBuilder()->helpers([
             'Menu.Menu',
             'Form' => [

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -129,7 +129,9 @@ class AppController extends Controller
         $this->_generateApiToken();
 
         // Use AdminLTE View instead of our App\View
-        $this->viewBuilder()->className('AdminLTE.AdminLTE');
+        if (!$this->request->is('ajax')) {
+            $this->viewBuilder()->className('AdminLTE.AdminLTE');
+        }
         $this->viewBuilder()->helpers([
             'Menu.Menu',
             'Form' => [


### PR DESCRIPTION
If we specify `AdminLTE` as viewBuilder's className, it re-routes
AJAX requests via `src/Template/Controller/json/action.ctp` which
we don't need, if we simply serialize the result of action response.

Setting `className` only for non-AJAX methods avoids this misrouting
of response, and keeps custom rendering fixes on default layouts,
aka 'session flash' messages.