### PR TITLE
New users are Active by default (task #4457)

### DIFF
--- a/src/Template/Plugin/CakeDC/Users/Users/add.ctp
+++ b/src/Template/Plugin/CakeDC/Users/Users/add.ctp
@@ -55,6 +55,7 @@ echo $this->Html->scriptBlock(
                                 'type' => 'checkbox',
                                 'class' => 'square',
                                 'label' => false,
+                                'checked' => 'checked',
                                 'templates' => [
                                     'inputContainer' => '<div class="{{required}}">' . $this->Form->label('Users.active') . '<div class="clearfix"></div>{{content}}</div>'
                                 ]


### PR DESCRIPTION
When creating a new user via the admin web interface, the account
will be set as Active by default.  This should solve the issue
with new users not being able to login, if the administrator forgot
to check the Active checkbox.