### PR TITLE
Disable email sending (task #4458)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,7 @@ CHOWN_USER=nginx
 CHGRP_GROUP=nginx
 
 # Email configuration
+EMAIL_ENABLED=1
 SMTP_ENABLED=1
 SMTP_HOST=localhost
 SMTP_PORT=25

--- a/config/app.php
+++ b/config/app.php
@@ -24,6 +24,11 @@ $cookieHttpOnly = (bool)env('APP_SESSION_COOKIE_HTTP_ONLY');
 $useOnlyCookies = (bool)env('APP_SESSION_USE_ONLY_COOKIES');
 $sessionTimeout = (int)env('APP_SESSION_TIMEOUT');
 
+// If EMAIL_ENABLED is false, use Debug transport.  Otherwise, use
+// either the Smtp transport if enabled or fallback on Mail transport.
+$emailTransport = (bool)getenv('SMTP_ENABLED') ? 'Smtp' : 'Mail';
+$emailTransport = (bool)getenv('EMAIL_ENABLED') ? $emailTransport : 'Debug';
+
 // If the configuration is missing, fallback on
 // PHP configuration.  If that is missing too,
 // assume default.
@@ -223,7 +228,7 @@ return [
      */
     'EmailTransport' => [
         'default' => [
-            'className' => (bool)getenv('SMTP_ENABLED') ? 'Smtp' : 'Mail',
+            'className' => $emailTransport,
             // The following keys are used in SMTP transports
             'host' => getenv('SMTP_HOST') ?: 'localhost',
             'port' => getenv('SMTP_PORT') ?: 25,

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -151,12 +151,19 @@ if (!Configure::read('App.fullBaseUrl')) {
     unset($httpHost, $s);
 }
 
+// Configure::consume() reads and deletes the value.
+// This is useful for consistency and security reasons.
 Cache::config(Configure::consume('Cache'));
 ConnectionManager::config(Configure::consume('Datasources'));
-Email::configTransport(Configure::consume('EmailTransport'));
-Email::config(Configure::consume('Email'));
 Log::config(Configure::consume('Log'));
 Security::salt(Configure::consume('Security.salt'));
+
+// Read, rather than consume, since we have some logic that
+// needs to know if email sending is enabled or not.
+// See `src/Shell/EmailShell.php` for example, but also in
+// plugins.
+Email::configTransport(Configure::read('EmailTransport'));
+Email::config(Configure::read('Email'));
 
 /**
  * The default crypto extension in 3.0 is OpenSSL.

--- a/src/Shell/EmailShell.php
+++ b/src/Shell/EmailShell.php
@@ -3,6 +3,7 @@
 namespace App\Shell;
 
 use Cake\Console\Shell;
+use Cake\Core\Configure;
 use Cake\Mailer\Email;
 
 class EmailShell extends Shell
@@ -62,6 +63,12 @@ class EmailShell extends Shell
      */
     public function main()
     {
+        $emailTransport = Configure::read('EmailTransport.default.className');
+        if ($emailTransport == 'Debug') {
+            $this->out('FAILED');
+            $this->abort('Email sending is disabled via the Debug transport');
+        }
+
         // Get the settings
         $to = $this->args[0];
         $domain = !empty($this->params['domain']) ? $this->params['domain'] : $this->_getDefaultDomain();


### PR DESCRIPTION
Use `EMAIL_ENABLED` flag in `.env` to enable or disable sending of emails.  Default is `true`.