### PR TITLE
Page title (task #4665)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -25,6 +25,8 @@ use Cake\Network\Exception\NotFoundException;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Security;
 use Firebase\JWT\JWT;
+use Qobo\Utils\ModuleConfig\ConfigType;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 use RolesCapabilities\Capability;
 use RolesCapabilities\CapabilityTrait;
 use Search\Controller\SearchTrait;
@@ -158,8 +160,21 @@ class AppController extends Controller
 
         $this->viewBuilder()->theme('AdminLTE');
         $this->viewBuilder()->layout('adminlte');
+
+        $title = $this->name;
+        try {
+            $mc = new ModuleConfig(ConfigType::MODULE(), $this->name);
+            $config = $mc->parse();
+            if (!empty($config->table->alias)) {
+                $title = $config->table->alias;
+            }
+        } catch (Exception $e) {
+            // do nothing
+        }
+
         // overwrite theme title before setting the theme
-        Configure::write('Theme.title', $this->name);
+        // NOTE: we set controller specific title, to work around requestAction() calls.
+        Configure::write('Theme.title.' . $this->name, $title);
         $this->set('theme', Configure::read('Theme'));
     }
 

--- a/src/Template/Layout/adminlte.ctp
+++ b/src/Template/Layout/adminlte.ctp
@@ -4,7 +4,7 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title><?php echo Configure::read('Theme.title'); ?></title>
+        <title><?php echo Configure::read('Theme.title.' . $this->name); ?></title>
         <!-- Tell the browser to be responsive to screen width -->
         <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
         <?php echo $this->Html->css('AdminLTE./bootstrap/css/bootstrap.min'); ?>


### PR DESCRIPTION
We set and use controller specific title for the project's layout to fix the issue of page title getting overwritten in Views that use the `requestAction()` method.