### PR TITLE
Swagger improvements (task #4701)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -214,7 +214,9 @@ Plugin::load('AuditStash');
 Plugin::load('DatabaseLog', ['routes' => true]);
 Plugin::load('Search', ['bootstrap' => true, 'routes' => true]);
 Plugin::load('Burzum/FileStorage');
-Plugin::load('Alt3/Swagger', ['routes' => true]);
+if (Configure::read('API.auth')) {
+    Plugin::load('Alt3/Swagger', ['routes' => true]);
+}
 Plugin::load('AdminLTE', ['bootstrap' => true, 'routes' => true]);
 
 // Only load JwtAuth plugin if API authentication is enabled

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -214,7 +214,7 @@ Plugin::load('AuditStash');
 Plugin::load('DatabaseLog', ['routes' => true]);
 Plugin::load('Search', ['bootstrap' => true, 'routes' => true]);
 Plugin::load('Burzum/FileStorage');
-if (Configure::read('API.auth')) {
+if (Configure::read('Swagger.crawl') && Configure::read('API.auth')) {
     Plugin::load('Alt3/Swagger', ['routes' => true]);
 }
 Plugin::load('AdminLTE', ['bootstrap' => true, 'routes' => true]);

--- a/config/swagger.php
+++ b/config/swagger.php
@@ -1,6 +1,6 @@
 <?php
+use App\Swagger\Analyser;
 use Cake\Core\Configure;
-use CsvMigrations\Swagger\Analyser;
 
 return [
     'Swagger' => [

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Controller\Api;
 
+use App\Swagger\Annotation;
 use Cake\Core\Configure;
 use Cake\Network\Exception\ForbiddenException;
 use CsvMigrations\Controller\Api\AppController as BaseController;
@@ -38,5 +39,21 @@ class AppController extends BaseController
         $this->loadComponent('RolesCapabilities.Capability', [
             'currentRequest' => $this->request->params
         ]);
+    }
+
+    /**
+     * Generates Swagger annotations
+     *
+     * Instantiates CsvAnnotation with required parameters
+     * and returns its generated swagger annotation content.
+     *
+     * @param string $path File path
+     * @return string
+     */
+    public static function generateSwaggerAnnotations($path)
+    {
+        $csvAnnotation = new Annotation(get_called_class(), $path);
+
+        return $csvAnnotation->getContent();
     }
 }

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -7,6 +7,16 @@ use Cake\Network\Exception\ForbiddenException;
 use CsvMigrations\Controller\Api\AppController as BaseController;
 use RolesCapabilities\CapabilityTrait;
 
+/**
+    @SWG\Swagger(
+        @SWG\Info(
+            title="API Documentation",
+            description="Interactive API documentation powered by Swagger.io",
+            termsOfService="http://swagger.io/terms/",
+            version="1.0.0"
+        )
+    )
+ */
 class AppController extends BaseController
 {
     use CapabilityTrait;

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Controller\Api;
 
+use Cake\Core\Configure;
 use Cake\Network\Exception\ForbiddenException;
 use CsvMigrations\Controller\Api\AppController as BaseController;
 use RolesCapabilities\CapabilityTrait;
@@ -16,6 +17,18 @@ class AppController extends BaseController
     {
         parent::initialize();
 
+        if (Configure::read('API.auth')) {
+            $this->enableAuthorization();
+        }
+    }
+
+    /**
+     * Enable API authorization checks.
+     *
+     * @return void
+     */
+    protected function enableAuthorization()
+    {
         $hasAccess = $this->_checkAccess($this->request->params, $this->Auth->user());
 
         if (!$hasAccess) {

--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -14,6 +14,13 @@ use RolesCapabilities\CapabilityTrait;
             description="Interactive API documentation powered by Swagger.io",
             termsOfService="http://swagger.io/terms/",
             version="1.0.0"
+        ),
+        @SWG\SecurityScheme(
+            securityDefinition="Bearer",
+            description="Json Web Tokens (JWT)",
+            type="apiKey",
+            name="token",
+            in="query"
         )
     )
  */

--- a/src/Controller/Api/UsersController.php
+++ b/src/Controller/Api/UsersController.php
@@ -7,6 +7,39 @@ use Cake\Network\Exception\UnauthorizedException;
 use Cake\Utility\Security;
 use Firebase\JWT\JWT;
 
+/**
+    @SWG\Post(
+        path="/api/users/token",
+        summary="API authentication",
+        tags={"Authentication"},
+        consumes={"application/json"},
+        produces={"application/json"},
+        @SWG\Parameter(
+            name="body",
+            in="body",
+            description="API credentials",
+            required=true,
+            @SWG\Schema(ref="#/definitions/AuthToken")
+        ),
+        @SWG\Response(
+            response="200",
+            description="Successful operation"
+        )
+    )
+
+    @SWG\Definition(
+        definition="AuthToken",
+        required={"username,password"},
+        @SWG\Property(
+            property="username",
+            type="string"
+        ),
+        @SWG\Property(
+            property="password",
+            type="string"
+        )
+    )
+ */
 class UsersController extends AppController
 {
     /**

--- a/src/Swagger/Analyser.php
+++ b/src/Swagger/Analyser.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Swagger;
+
+use Cake\Core\App;
+use Swagger\Context;
+use Swagger\StaticAnalyser;
+
+class Analyser extends StaticAnalyser
+{
+    /**
+     * Extract and process all doc-comments from an
+     * auto-generated swagger annotations content.
+     *
+     * @param string $filename Path to a php file.
+     * @return Analysis
+     */
+    public function fromFile($filename)
+    {
+        $className = basename($filename, '.php');
+        $className = App::className($className, 'Controller/Api');
+
+        $tokens = [];
+        if ($className) {
+            $annotations = $className::generateSwaggerAnnotations($filename);
+            $tokens = token_get_all($annotations);
+        }
+
+        return $this->fromTokens($tokens, new Context(['filename' => $filename]));
+    }
+}

--- a/src/Swagger/Annotation.php
+++ b/src/Swagger/Annotation.php
@@ -1,0 +1,369 @@
+<?php
+namespace App\Swagger;
+
+use Cake\Core\App;
+use Cake\Database\Exception;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+
+class Annotation
+{
+    /**
+     * Annotation content.
+     *
+     * @var string
+     */
+    protected $_content = null;
+
+    /**
+     * Mapping of database column types to swagger types.
+     *
+     * @var array
+     */
+    protected $_db2swagger = [
+        'datetime' => 'dateTime',
+        'decimal' => 'float'
+    ];
+
+    /**
+     * Class name to generate annotations for.
+     *
+     * @var string
+     */
+    protected $_className = '';
+
+    /**
+     * Full path name of the file to generate annotations for.
+     *
+     * @var string
+     */
+    protected $_path = '';
+
+    /**
+     * Swagger annotations.
+     *
+     * @var array
+     */
+    protected $_annotations = [
+        'definition' => '/**
+            @SWG\Definition(
+                definition="{{definition}}",
+                required={"{{required}}"},
+                {{properties}}
+            )
+         */',
+        'property' => '
+            @SWG\Property(
+                property="{{property}}",
+                type="{{type}}"
+            )',
+        'paths' => '/**
+            @SWG\Get(
+                path="/api/{{module_url}}",
+                summary="Retrieve a list of {{module_human_plural}}",
+                tags={"{{module_human_plural}}"},
+                consumes={"application/json"},
+                produces={"application/json"},
+                @SWG\Parameter(
+                    name="limit",
+                    description="Results limit",
+                    in="query",
+                    required=false,
+                    type="integer",
+                    default=""
+                ),
+                @SWG\Parameter(
+                    name="sort",
+                    description="Sort results by field",
+                    in="query",
+                    required=false,
+                    type="string",
+                    enum={ {{sort_fields}} }
+                ),
+                @SWG\Parameter(
+                    name="direction",
+                    description="Sorting direction",
+                    in="query",
+                    required=false,
+                    type="string",
+                    enum={"asc", "desc"}
+                ),
+                @SWG\Response(
+                    response="200",
+                    description="Successful operation",
+                    @SWG\Schema(
+                        type="array",
+                        ref="#/definitions/{{module_singular}}"
+                    )
+                )
+            )
+
+            @SWG\Get(
+                path="/api/{{module_url}}/view/{id}",
+                summary="Retrieve a {{module_human_singular}} by ID",
+                tags={"{{module_human_plural}}"},
+                consumes={"application/json"},
+                produces={"application/json"},
+                @SWG\Parameter(
+                    name="id",
+                    description="{{module_human_singular}} ID",
+                    in="path",
+                    required=true,
+                    type="string",
+                    default=""
+                ),
+                @SWG\Response(
+                    response="200",
+                    description="Successful operation",
+                    @SWG\Schema(
+                        type="array",
+                        ref="#/definitions/{{module_singular}}"
+                    )
+                ),
+                @SWG\Response(
+                    response="404",
+                    description="Not found"
+                )
+            )
+
+            @SWG\Post(
+                path="/api/{{module_url}}/add",
+                summary="Add new {{module_human_singular}}",
+                tags={"{{module_human_plural}}"},
+                consumes={"application/json"},
+                produces={"application/json"},
+                @SWG\Parameter(
+                    name="body",
+                    in="body",
+                    description="{{module_human_singular}} object to be added to the system",
+                    required=true,
+                    @SWG\Schema(ref="#/definitions/{{module_singular}}")
+                ),
+                @SWG\Response(
+                    response="201",
+                    description="Successful operation"
+                )
+            )
+
+            @SWG\Put(
+                path="/api/{{module_url}}/edit/{id}",
+                summary="Edit an existing {{module_human_singular}}",
+                tags={"{{module_human_plural}}"},
+                consumes={"application/json"},
+                produces={"application/json"},
+                @SWG\Parameter(
+                    name="id",
+                    description="{{module_human_singular}} ID",
+                    in="path",
+                    required=true,
+                    type="string",
+                    default=""
+                ),
+                @SWG\Parameter(
+                    name="body",
+                    in="body",
+                    description="{{module_human_singular}} name",
+                    required=true,
+                    @SWG\Schema(ref="#/definitions/{{module_singular}}")
+                ),
+                @SWG\Response(
+                    response="200",
+                    description="Successful operation"
+                ),
+                @SWG\Response(
+                    response="404",
+                    description="Not found"
+                )
+            )
+        */'
+    ];
+
+    /**
+     * Constructor method.
+     *
+     * @param string $className Class name
+     * @param string $path File path
+     */
+    public function __construct($className, $path)
+    {
+        $this->_className = App::shortName($className, 'Controller/Api', 'Controller');
+
+        $this->_path = $path;
+    }
+
+    /**
+     * Swagger annotation content getter.
+     *
+     * @return string
+     */
+    public function getContent()
+    {
+        if (empty($this->_content)) {
+            $this->_generateContent();
+        }
+
+        return $this->_content;
+    }
+
+    /**
+     * Swagger annotation content setter.
+     *
+     * @param string $content The content
+     * @return void
+     */
+    public function setContent($content)
+    {
+        $this->_content = $content;
+    }
+
+    /**
+     * Method that generates and sets swagger annotation content.
+     *
+     * @return void
+     */
+    protected function _generateContent()
+    {
+        $result = file_get_contents($this->_path);
+
+        $properties = $this->_getProperties();
+
+        $definition = $this->_getDefinition($properties);
+
+        $paths = $this->_getPaths();
+
+        $result = preg_replace('/(^class\s)/im', implode("\n", [$definition, $paths]) . "\n$1", $result);
+
+        $this->setContent(trim($result));
+    }
+
+    /**
+     * Generates and returns swagger properties annotation.
+     *
+     * It uses current table's column definitions to generate
+     * swagger property annotation on the fly.
+     *
+     * @return string
+     */
+    protected function _getProperties()
+    {
+        $result = null;
+        $table = TableRegistry::get($this->_className);
+
+        $entity = $table->newEntity();
+        $hiddenProperties = $entity->hiddenProperties();
+        try {
+            $columns = $table->schema()->columns();
+            $columns = array_diff($columns, $hiddenProperties);
+        } catch (Exception $e) {
+            return $result;
+        }
+
+        foreach ($columns as $column) {
+            $data = $table->schema()->column($column);
+            $placeholders = [
+                '{{property}}' => $column,
+                '{{type}}' => array_key_exists($data['type'], $this->_db2swagger) ?
+                    $this->_db2swagger[$data['type']] :
+                    $data['type']
+            ];
+            $result[] = str_replace(
+                array_keys($placeholders),
+                array_values($placeholders),
+                $this->_annotations['property']
+            );
+        }
+
+        $result = implode(',', $result);
+
+        return $result;
+    }
+
+    /**
+     * Generates and returns swagger definition (model) annotation.
+     *
+     * It uses current table's column definitions to construct a list
+     * of required columns and uses properties argument to generate
+     * definition annotation.
+     *
+     * @param  string $properties Swagger properties annotations
+     * @return string
+     */
+    protected function _getDefinition($properties)
+    {
+        $result = null;
+        $table = TableRegistry::get($this->_className);
+
+        $entity = $table->newEntity();
+        $hiddenProperties = $entity->hiddenProperties();
+        try {
+            $columns = $table->schema()->columns();
+            $columns = array_diff($columns, $hiddenProperties);
+        } catch (Exception $e) {
+            return $result;
+        }
+
+        $required = [];
+        foreach ($columns as $column) {
+            $data = $table->schema()->column($column);
+            if ($data['null']) {
+                continue;
+            }
+            $required[] = $column;
+        }
+
+        $placeholders = [
+            '{{definition}}' => Inflector::singularize($this->_className),
+            '{{required}}' => implode(',', $required),
+            '{{properties}}' => (string)$properties
+        ];
+
+        $result = str_replace(
+            array_keys($placeholders),
+            array_values($placeholders),
+            $this->_annotations['definition']
+        );
+
+        return $result;
+    }
+
+    /**
+     * Generates and returns swagger paths (controller) annotation.
+     *
+     * It uses current table's column definitions to construct a list
+     * of all visible columns to be used as sorting fields and generates
+     * paths annotations on the fly.
+     *
+     * @return array
+     */
+    protected function _getPaths()
+    {
+        $result = null;
+        $table = TableRegistry::get($this->_className);
+
+        $entity = $table->newEntity();
+        $hiddenProperties = $entity->hiddenProperties();
+        try {
+            $fields = $table->schema()->columns();
+            $fields = array_diff($fields, $hiddenProperties);
+            sort($fields);
+        } catch (Exception $e) {
+            return $result;
+        }
+
+        $placeholders = [
+            '{{module_human_singular}}' => Inflector::singularize(Inflector::humanize(Inflector::underscore($this->_className))),
+            '{{module_human_plural}}' => Inflector::pluralize(Inflector::humanize(Inflector::underscore($this->_className))),
+            '{{module_singular}}' => Inflector::singularize($this->_className),
+            '{{module_url}}' => Inflector::dasherize($this->_className),
+            '{{sort_fields}}' => '"' . implode('", "', $fields) . '"'
+        ];
+
+        $result = str_replace(
+            array_keys($placeholders),
+            array_values($placeholders),
+            $this->_annotations['paths']
+        );
+
+        return $result;
+    }
+}

--- a/src/Template/Plugin/Alt3/Swagger/Ui/index.ctp
+++ b/src/Template/Plugin/Alt3/Swagger/Ui/index.ctp
@@ -141,7 +141,7 @@ if (!isset($uiConfig['api_selector'])) {
         <?php if ($uiConfig['api_selector'] === true) : ?>
             <form id='api_selector'>
                 <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-                <div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
+                <div id='auth_container'></div>
                 <div class='input'><a id="explore" href="#" data-sw-translate>Explore</a></div>
             </form>
         <?php endif; ?>

--- a/src/Template/Plugin/Alt3/Swagger/Ui/index.ctp
+++ b/src/Template/Plugin/Alt3/Swagger/Ui/index.ctp
@@ -1,0 +1,154 @@
+<?php
+
+use Cake\View\Helper\HtmlHelper;
+use Cake\View\Helper\UrlHelper;
+
+if (empty($uiConfig['title'])) {
+    $uiConfig['title'] = "cakephp-swagger";
+}
+
+if (!isset($uiConfig['validator'])) {
+    $uiConfig['validator'] = true;
+}
+
+if (!isset($uiConfig['api_selector'])) {
+    $uiConfig['api_selector'] = true;
+}
+
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title><?= $uiConfig['title'] ?></title>
+    <?php
+
+    // favicons
+    echo $this->Html->meta([
+        'link' => $this->Url->assetUrl('Alt3/Swagger./images/favicon-32x32.png', ['fullBase' => true]),
+        'rel' => 'icon',
+        'sizes' => '32x32',
+        'type' => 'image/png',
+    ]);
+    echo $this->Html->meta([
+        'link' => $this->Url->assetUrl('Alt3/Swagger./images/favicon-16x16.png', ['fullBase' => true]),
+        'rel' => 'icon',
+        'sizes' => '16x16',
+        'type' => 'image/png'
+    ]);
+
+    // screen stylesheets
+    echo $this->Html->css([
+        'Alt3/Swagger.typography.css',
+        'Alt3/Swagger.reset.css',
+        'Alt3/Swagger.screen.css',
+    ], ['media' => 'screen', 'once' => false, 'fullBase' => true]);
+
+    // print stylesheet
+    echo $this->Html->css([
+        'Alt3/Swagger.reset.css',
+        'Alt3/Swagger.print.css',
+    ], ['media' => 'print', 'once' => false, 'fullBase' => true]);
+
+    // javascript libraries
+    echo $this->Html->script([
+		'Alt3/Swagger./lib/object-assign-pollyfill.js',
+        'Alt3/Swagger./lib/jquery-1.8.0.min.js',
+        'Alt3/Swagger./lib/jquery.slideto.min.js',
+        'Alt3/Swagger./lib/jquery.wiggle.min.js',
+        'Alt3/Swagger./lib/jquery.ba-bbq.min.js',
+        'Alt3/Swagger./lib/handlebars-4.0.5.js',
+        'Alt3/Swagger./lib/lodash.min.js',
+        'Alt3/Swagger./lib/backbone-min.js',
+        'Alt3/Swagger./swagger-ui.js',
+        'Alt3/Swagger./lib/highlight.9.1.0.pack.js',
+        'Alt3/Swagger./lib/highlight.9.1.0.pack_extended.js',
+        'Alt3/Swagger./lib/jsoneditor.min.js',
+        'Alt3/Swagger./lib/marked.js',
+        'Alt3/Swagger./lib/swagger-oauth.js'
+    ], ['fullBase' => true]);
+
+    ?>
+
+    <!-- Some basic translations -->
+    <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
+    <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
+    <!-- <script src='lang/en.js' type='text/javascript'></script> -->
+
+    <script type="text/javascript">
+        $(function () {
+            var url = window.location.search.match(/url=([^&]+)/);
+            if (url && url.length > 1) {
+                url = decodeURIComponent(url[1]);
+            } else {
+                url = "<?= $url ?>";
+            }
+
+			hljs.configure({
+				highlightSizeThreshold: 5000
+			});
+
+            // Pre load translate...
+            if(window.SwaggerTranslator) {
+                window.SwaggerTranslator.translate();
+            }
+            window.swaggerUi = new SwaggerUi({
+                url: url,
+                <?php if ($uiConfig['validator'] === false) : ?>
+                    validatorUrl: false,
+                <?php endif ?>
+                dom_id: "swagger-ui-container",
+                supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+                onComplete: function(swaggerApi, swaggerUi){
+                    if(typeof initOAuth == "function") {
+                        initOAuth({
+                            clientId: "your-client-id",
+                            clientSecret: "your-client-secret-if-required",
+                            realm: "your-realms",
+                            appName: "your-app-name",
+                            scopeSeparator: ","
+                        });
+                    }
+
+                    if(window.SwaggerTranslator) {
+                        window.SwaggerTranslator.translate();
+                    }
+                },
+                onFailure: function(data) {
+                    log("Unable to Load SwaggerUI");
+                },
+                docExpansion: "none",
+                jsonEditor: false,
+                defaultModelRendering: 'schema',
+                showRequestHeaders: false
+            });
+
+            window.swaggerUi.load();
+
+            function log() {
+                if ('console' in window) {
+                    console.log.apply(console, arguments);
+                }
+            }
+        });
+    </script>
+</head>
+
+<body class="swagger-section">
+<div id='header'>
+    <div class="swagger-ui-wrap">
+        <a id="logo" href="http://swagger.io">swagger</a>
+        <?php if ($uiConfig['api_selector'] === true) : ?>
+            <form id='api_selector'>
+                <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
+                <div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
+                <div class='input'><a id="explore" href="#" data-sw-translate>Explore</a></div>
+            </form>
+        <?php endif; ?>
+    </div>
+</div>
+
+<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
+<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+</body>
+</html>


### PR DESCRIPTION
- Copied swagger annotations generator logic from CSV Migrations plugin (https://github.com/QoboLtd/cakephp-csv-migrations/pull/493).
- Conditionally loading Swagger plugin, only if API authentication is enabled.
- Set swagger annotations for API authentication end-point.
- Added Swagger security scheme annotation for JWT authentication.
- Fixed Swagger template to include authorization button.