### PR TITLE
Modifying ExceptionRenderer for Logged users (task #4982)

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -198,7 +198,7 @@ return [
      */
     'Error' => [
         'errorLevel' => E_ALL & ~E_DEPRECATED,
-        'exceptionRenderer' => 'Cake\Error\ExceptionRenderer',
+        'exceptionRenderer' => 'App\Error\AppExceptionRenderer',
         'skipLog' => [],
         'log' => true,
         'trace' => true,

--- a/src/Controller/SystemController.php
+++ b/src/Controller/SystemController.php
@@ -19,4 +19,17 @@ class SystemController extends AppController
     public function info()
     {
     }
+
+    /**
+     * Error method
+     *
+     * Default redirect method for loggedin users
+     * in case the system throws an error on switched off
+     * debug. Otherwise, it'll use native Cake Error pages.
+     *
+     * @return void
+     */
+    public function error()
+    {
+    }
 }

--- a/src/Error/AppExceptionRenderer.php
+++ b/src/Error/AppExceptionRenderer.php
@@ -36,7 +36,8 @@ class AppExceptionRenderer extends ExceptionRenderer
                     '_serialize' => ['message', 'code', 'url'],
                 ];
 
-                $res = $this->controller->request->session()->write('currentError', json_encode($data));
+                // adding generated error info into custom session variable for system/error page.
+                $this->controller->request->session()->write('currentError', json_encode($data));
 
                 return $this->controller->redirect('/system/error');
             }

--- a/src/Error/AppExceptionRenderer.php
+++ b/src/Error/AppExceptionRenderer.php
@@ -22,27 +22,25 @@ class AppExceptionRenderer extends ExceptionRenderer
         $this->controller->Auth->config('authorize', false);
         $currentUser = $this->controller->Auth->user();
 
-        if (!$isDebug) {
-            if (!empty($currentUser)) {
-                $exception = $this->error;
-                $code = $this->_code($exception);
-                $message = $this->_message($this->error, $this->error->getCode());
-
-                $data = [
-                    'code' => $code,
-                    'message' => $message,
-                    'url' => $this->controller->request->getRequestTarget(),
-                    'error' => $this->_unwrap($exception),
-                    '_serialize' => ['message', 'code', 'url'],
-                ];
-
-                // adding generated error info into custom session variable for system/error page.
-                $this->controller->request->session()->write('currentError', json_encode($data));
-
-                return $this->controller->redirect('/system/error');
-            }
+        if (empty($currentUser) || $isDebug) {
+            return parent::render();
         }
 
-        return parent::render();
+        $exception = $this->error;
+        $code = $this->_code($exception);
+        $message = $this->_message($this->error, $this->error->getCode());
+
+        $data = [
+            'code' => $code,
+            'message' => $message,
+            'url' => $this->controller->request->getRequestTarget(),
+            'error' => $this->_unwrap($exception),
+            '_serialize' => ['message', 'code', 'url'],
+        ];
+
+        // adding generated error info into custom session variable for system/error page.
+        $this->controller->request->session()->write('currentError', json_encode($data));
+
+        return $this->controller->redirect('/system/error');
     }
 }

--- a/src/Error/AppExceptionRenderer.php
+++ b/src/Error/AppExceptionRenderer.php
@@ -1,0 +1,47 @@
+<?php
+namespace App\Error;
+
+use Cake\Core\Configure;
+use Cake\Error\ExceptionRenderer;
+
+class AppExceptionRenderer extends ExceptionRenderer
+{
+    /**
+     * Render Error Page.
+     *
+     * We overwrite the render function just to remain
+     * on the same layout in case the user got an error
+     * and still logged in to the sytem.
+     *
+     * @return mixed
+     */
+    public function render()
+    {
+        $isDebug = Configure::read('debug');
+        $this->controller->loadComponent('CakeDC/Users.UsersAuth');
+        $this->controller->Auth->config('authorize', false);
+        $currentUser = $this->controller->Auth->user();
+
+        if (!$isDebug) {
+            if (!empty($currentUser)) {
+                $exception = $this->error;
+                $code = $this->_code($exception);
+                $message = $this->_message($this->error, $this->error->getCode());
+
+                $data = [
+                    'code' => $code,
+                    'message' => $message,
+                    'url' => $this->controller->request->getRequestTarget(),
+                    'error' => $this->_unwrap($exception),
+                    '_serialize' => ['message', 'code', 'url'],
+                ];
+
+                $res = $this->controller->request->session()->write('currentError', json_encode($data));
+
+                return $this->controller->redirect('/system/error');
+            }
+        }
+
+        return parent::render();
+    }
+}

--- a/src/Template/System/error.ctp
+++ b/src/Template/System/error.ctp
@@ -8,7 +8,10 @@ if (empty($user)) {
 
 $currentError = $this->request->session()->read('currentError');
 
-$url = $code = $message = '';
+$code = '000';
+$message = 'Unknown Error';
+
+$url = '';
 
 if (!empty($currentError)) {
     $currentError = json_decode($currentError, true);

--- a/src/Template/System/error.ctp
+++ b/src/Template/System/error.ctp
@@ -1,0 +1,40 @@
+<?php
+
+use Cake\Routing\Router;
+
+if (empty($user)) {
+    $this->layout = 'error';
+}
+
+$currentError = $this->request->session()->read('currentError');
+
+$url = $code = $message = '';
+
+if (!empty($currentError)) {
+    $currentError = json_decode($currentError, true);
+
+    $url = $currentError['url'];
+    $code = $currentError['code'];
+    $message = $currentError['message'];
+}
+?>
+<div class="container">
+<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        <div class="box box-danger box-solid" style="margin-top:80px;">
+            <div class="box-header with-border">
+                <h3 class="box-title">
+                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                    <?= __d('cake', 'Error') ?> <?= h($code) ?>: <?= h($message) ?>
+                </h3>
+            </div>
+            <div class="box-body">
+                <?php echo 'There was a problem processing your request.  Please notify your system administrator.'; ?>
+            </div>
+            <div class="box-footer">
+                <b>URL: </b><?= h(Router::url($url, true)) ?>
+            </div>
+        </div>
+    </div>
+</div>
+</div>


### PR DESCRIPTION
We don't want to break user navigation for loggedin users.
In case we get 4xx/5xx error, we replace the content of the
page but keepting sidebars and nav-bar components.

It works only for disabled debug. Otherwise, the page
will be using native CakePHP error templates.