### PR TITLE
CLI logging to database (task #5039)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
     - ./bin/composer install --no-interaction --no-progress --no-suggest
     - mkdir -p build/logs
     - ./vendor/bin/phake dotenv:create CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_USER=root
-    - if [ -d "config/CsvMigrations" ] || [ -d "config/Modules" ] ; then ./bin/cake validate ; fi
     - ./vendor/bin/phake app:install
 
 before_script:

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -229,6 +229,7 @@ group('cakephp', function () {
             printInfo("Testing migration for plugin $plugin");
             $command = getenv('CAKE_CONSOLE') . " migrations migrate --quiet -p $plugin --connection=test";
             printInfo("Command: $command");
+            doShellCommand($command);
         }
         // Run app migrations
         printInfo("Testing application migrations");

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -282,6 +282,7 @@ group('cakephp', function () {
             'menu import',
             'add_dblist_permissions',
             'dblists_add',
+            'validate' // run after dblists are populated
         ];
 
         foreach ($scripts as $script) {

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -229,7 +229,13 @@ group('cakephp', function () {
             printInfo("Testing migration for plugin $plugin");
             $command = getenv('CAKE_CONSOLE') . " migrations migrate --quiet -p $plugin --connection=test";
             printInfo("Command: $command");
-            doShellCommand($command);
+            try {
+                doShellCommand($command);
+            } catch (\Exception $e) {
+                if ('DatabaseLog' !== $plugin) {
+                    throw $e;
+                }
+            }
         }
         // Run app migrations
         printInfo("Testing application migrations");

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -229,13 +229,6 @@ group('cakephp', function () {
             printInfo("Testing migration for plugin $plugin");
             $command = getenv('CAKE_CONSOLE') . " migrations migrate --quiet -p $plugin --connection=test";
             printInfo("Command: $command");
-            try {
-                doShellCommand($command);
-            } catch (\Exception $e) {
-                if ('DatabaseLog' !== $plugin) {
-                    throw $e;
-                }
-            }
         }
         // Run app migrations
         printInfo("Testing application migrations");
@@ -265,7 +258,13 @@ group('cakephp', function () {
             printInfo("Running migration for plugin $plugin");
             $command = getenv('CAKE_CONSOLE') . " migrations migrate --quiet -p $plugin";
             printInfo("Command: $command");
-            doShellCommand($command);
+            try {
+                doShellCommand($command);
+            } catch (\Exception $e) {
+                if ('DatabaseLog' !== $plugin) {
+                    throw $e;
+                }
+            }
         }
         // Run app migrations
         printInfo("Running application migrations");

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -14,7 +14,6 @@ pipelines:
           - chmod -R u+rwX,go-rwX ~/.ssh
           - ./bin/composer install --no-interaction --no-progress --no-suggest
           - ./vendor/bin/phake dotenv:create CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_ADMIN_PASS=root DB_USER=root DB_PASS=root
-          - if [ -d "config/CsvMigrations" ] || [ -d "config/Modules" ] ; then ./bin/cake validate ; fi
           - ./vendor/bin/phake app:install
           - ./vendor/bin/phpunit --group example --no-coverage
           - ./vendor/bin/phpunit --exclude-group example --no-coverage

--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -21,21 +21,9 @@ use Cake\Core\Plugin;
  * be put here.
  */
 
-// Set logs to default file mode.
-Configure::write('Log', [
-    'debug' => [
-        'className' => 'Cake\Log\Engine\FileLog',
-        'path' => LOGS,
-        'file' => 'cli-debug',
-        'levels' => ['debug'],
-    ],
-    'error' => [
-        'className' => 'Cake\Log\Engine\FileLog',
-        'path' => LOGS,
-        'file' => 'cli-error',
-        'levels' => ['notice', 'info', 'warning', 'error', 'critical', 'alert', 'emergency']
-    ],
-]);
+// Set logs to different files so they don't have permission conflicts.
+Configure::write('Log.debug.file', 'cli-debug');
+Configure::write('Log.error.file', 'cli-error');
 
 try {
     Plugin::load('Bake');


### PR DESCRIPTION
**Fixes**
- Set CLI logging back to the database.
- Moved validate shell to be executed after the application is initialized.

**Note**
`Databaselog` plugin ensures that the DB table exists during initialization of its `DatabaseLogsTable` class. This is done during our application's bootstrapping because we use the `DatabaseLog` engine for our logging functionality.

During migrations execution, an Exception is thrown, because `database_logs` table already exists for the reason explained above.