### PR TITLE
Adding system error url into skipActions (task #5063)

### DIFF
--- a/config/roles_capabilities.php
+++ b/config/roles_capabilities.php
@@ -8,6 +8,13 @@ return [
                 'menus',
                 'menu_items'
             ],
-        ]
+        ],
+        'accessCheck' => [
+            'skipActions' => [
+                'App\Controller\SystemController' => [
+                    'error',
+                ]
+            ],
+        ],
     ]
 ];


### PR DESCRIPTION
Since all our routes pass hasAccess check, we allow
system/error default error message to be accessed if
this route is not specified within roles-capabilities plugin.

This helps avoiding infinite redirects on error page.