### PR TITLE
bug fix on lookup action listener (task #5079)

### DIFF
--- a/src/Event/Controller/Api/LookupActionListener.php
+++ b/src/Event/Controller/Api/LookupActionListener.php
@@ -143,7 +143,7 @@ class LookupActionListener extends BaseActionListener
         ]);
 
         // recursive call
-        $query = $this->_alterQuery($table, $query, $request);
+        $this->_alterQuery($table, $query, $request);
 
         $result = $query->toArray();
 


### PR DESCRIPTION
  when altering query was overwriting the query variable with empty value