### PR TITLE
Plugin route count (task #4839)

### DIFF
--- a/src/Event/Plugin/Menu/View/MenuListener.php
+++ b/src/Event/Plugin/Menu/View/MenuListener.php
@@ -241,8 +241,8 @@ class MenuListener implements EventListenerInterface
         $url = $item['url'];
         $url = is_string($url) ? array_filter(explode('/', $url)) : $url;
 
-        // not a plugin route
-        if (3 > count($url)) {
+        // definitely not a plugin route
+        if (2 > count($url)) {
             return $item;
         }
 


### PR DESCRIPTION
A plugin route might consist two parts, for example on default actions such as index. So to properly filter plugin links during menu rendering we check for a URL count of at least two.