### PR TITLE
Removed DatabaseLog build checks

### DIFF
--- a/Phakefile.php
+++ b/Phakefile.php
@@ -259,13 +259,7 @@ group('cakephp', function () {
             printInfo("Running migration for plugin $plugin");
             $command = getenv('CAKE_CONSOLE') . " migrations migrate --quiet -p $plugin";
             printInfo("Command: $command");
-            try {
-                doShellCommand($command);
-            } catch (\Exception $e) {
-                if ('DatabaseLog' !== $plugin) {
-                    throw $e;
-                }
-            }
+            doShellCommand($command);
         }
         // Run app migrations
         printInfo("Running application migrations");

--- a/build/Robo/Command/App/App.php
+++ b/build/Robo/Command/App/App.php
@@ -274,11 +274,7 @@ class App extends AbstractCommand
         foreach ($tasks as $task) {
             $result = $task->run();
             if (!$result->wasSuccessful()) {
-                $data = $result->getData();
-                if (empty($data) || empty($data['plugin']) || $data['plugin'] != 'DatabaseLog') {
-                    return false;
-                }
-                $this->say("Ignore the above as we forgive the DatabaseLog errors");
+                return false;
             }
         }
 
@@ -441,11 +437,7 @@ class App extends AbstractCommand
         foreach ($tasks as $task) {
             $result = $task->run();
             if (!$result->wasSuccessful()) {
-                $data = $result->getData();
-                if (empty($data) || empty($data['plugin']) || $data['plugin'] != 'DatabaseLog') {
-                    return false;
-                }
-                $this->say("Ignore the above as we forgive the DatabaseLog errors");
+                return false;
             }
         }
 


### PR DESCRIPTION
Removed `DatabaseLog` plugin checks during build migrations run, since they were added as a temporary fix for a bug described in [this](https://github.com/QoboLtd/project-template-cakephp/pull/404/commits/cbd3f6b5a40cf870982e9597b96204c78eb6b58e) commit.

The plugin owner released a new version ([2.3.3](https://github.com/dereuromark/CakePHP-DatabaseLog/compare/2.3.2...2.3.3)), that includes the relevant fix.