### PR TITLE
Gravatar support for Users (task #5327)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -284,4 +284,4 @@ FeatureFactory::init();
 /**
  * Register custom database type(s)
  */
-Type::map('base64image', 'App\Database\Type\EncodedImageType');
+Type::map('base64', 'App\Database\Type\EncodedFileType');

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -59,6 +59,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Plugin;
+use Cake\Database\Type;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ErrorHandler;
 use Cake\Event\EventManager;
@@ -279,3 +280,8 @@ Configure::load('admin_lte', 'default');
 // Feature Factory initialization
 // IMPORTANT: this line should be placed at the end of the bootstrap file.
 FeatureFactory::init();
+
+/**
+ * Register custom database type(s)
+ */
+Type::map('base64image', 'App\Database\Type\EncodedImageType');

--- a/config/users.php
+++ b/config/users.php
@@ -16,4 +16,7 @@ return [
         // 'CakeDC/Users.RememberMe',
         'Form',
     ],
+    'Users.gravatar' => [
+        'active' => true
+    ]
 ];

--- a/config/users.php
+++ b/config/users.php
@@ -16,7 +16,13 @@ return [
         // 'CakeDC/Users.RememberMe',
         'Form',
     ],
-    'Users.gravatar' => [
-        'active' => false
+    'Users.avatar' => [
+        'type' => 'App\Avatar\Type\ImageSource',
+        'options' => [
+            '{{size}}' => 160, // used in Gravatar to set the desired image size
+            '{{default}}' => 'mm', // used in Gravatar to set the default/fallback themed image
+            '{{rating}}' => 'g', // used in Gravatar to set the desired image appropriateness rating
+            '{{src}}' => '/img/user-image-160x160.png' // used in ImageSource to set the default/fallback image
+        ]
     ]
 ];

--- a/config/users.php
+++ b/config/users.php
@@ -17,6 +17,6 @@ return [
         'Form',
     ],
     'Users.gravatar' => [
-        'active' => true
+        'active' => false
     ]
 ];

--- a/src/Avatar/AvatarInterface.php
+++ b/src/Avatar/AvatarInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Avatar;
+
+interface AvatarInterface
+{
+
+    /**
+     * Constructor method.
+     *
+     * @param array $options Avatar options
+     */
+    public function __construct(array $options);
+
+    /**
+     * Avatar getter method.
+     *
+     * @return string
+     */
+    public function get();
+}

--- a/src/Avatar/Service.php
+++ b/src/Avatar/Service.php
@@ -3,8 +3,17 @@ namespace App\Avatar;
 
 final class Service
 {
+    /**
+     * @var \App\Avatar\AvatarInterface
+     */
     private $avatar;
 
+    /**
+     * Constructor method.
+     *
+     * @param \App\Avatar\AvatarInterface $avatar Avatar instance
+     * @return void
+     */
     public function __construct(AvatarInterface $avatar)
     {
         $this->avatar = $avatar;

--- a/src/Avatar/Service.php
+++ b/src/Avatar/Service.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Avatar;
+
+final class Service
+{
+    private $avatar;
+
+    public function __construct(AvatarInterface $avatar)
+    {
+        $this->avatar = $avatar;
+    }
+
+    /**
+     * Fetches avatar image.
+     *
+     * @return string
+     */
+    public function getImage()
+    {
+        return $this->avatar->get();
+    }
+}

--- a/src/Avatar/Type/Gravatar.php
+++ b/src/Avatar/Type/Gravatar.php
@@ -1,0 +1,42 @@
+<?php
+namespace App\Avatar\Type;
+
+use App\Avatar\AvatarInterface;
+use Cake\Core\Configure;
+
+final class Gravatar implements AvatarInterface
+{
+    /**
+     * Gravatar default options.
+     *
+     * @var array
+     */
+    private $options = [
+        '{{email}}' => '',
+        '{{size}}' => 160,
+        '{{default}}' => 'mm',
+        '{{rating}}' => 'g'
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = array_merge($this->options, $options);
+
+        $this->options['{{email}}'] = md5(strtolower(trim($this->options['{{email}}'])));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get()
+    {
+        return str_replace(
+            array_keys($this->options),
+            array_values($this->options),
+            'https://www.gravatar.com/avatar/{{email}}?size={{size}}&default={{default}}&rating={{rating}}'
+        );
+    }
+}

--- a/src/Avatar/Type/Gravatar.php
+++ b/src/Avatar/Type/Gravatar.php
@@ -21,7 +21,7 @@ final class Gravatar implements AvatarInterface
     /**
      * {@inheritDoc}
      */
-    public function __construct(array $options = [])
+    public function __construct(array $options)
     {
         $this->options = array_merge($this->options, $options);
 

--- a/src/Avatar/Type/ImageSource.php
+++ b/src/Avatar/Type/ImageSource.php
@@ -28,6 +28,10 @@ final class ImageSource implements AvatarInterface
      */
     public function get()
     {
-        return str_replace(array_keys($this->options), array_values($this->options), '{{src}}');
+        return str_replace(
+            array_keys($this->options),
+            array_values($this->options),
+            '{{src}}'
+        );
     }
 }

--- a/src/Avatar/Type/ImageSource.php
+++ b/src/Avatar/Type/ImageSource.php
@@ -18,7 +18,7 @@ final class ImageSource implements AvatarInterface
     /**
      * {@inheritDoc}
      */
-    public function __construct(array $options = [])
+    public function __construct(array $options)
     {
         $this->options = array_merge($this->options, $options);
     }

--- a/src/Avatar/Type/ImageSource.php
+++ b/src/Avatar/Type/ImageSource.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Avatar\Type;
+
+use App\Avatar\AvatarInterface;
+use Cake\Core\Configure;
+
+final class ImageSource implements AvatarInterface
+{
+    /**
+     * Image default options.
+     *
+     * @var array
+     */
+    private $options = [
+        '{{src}}' => '/img/user-image-160x160.png',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = array_merge($this->options, $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get()
+    {
+        return str_replace(array_keys($this->options), array_values($this->options), '{{src}}');
+    }
+}

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -102,10 +102,7 @@ class UsersController extends AppController
             return $this->redirect($this->request->referer());
         }
 
-        // base64 encode image
-        $image = 'data:' . $data['type'] . ';base64,' . base64_encode(file_get_contents($data['tmp_name']));
-
-        $user = $this->Users->patchEntity($user, ['image' => $image]);
+        $user = $this->Users->patchEntity($user, ['image' => $data]);
 
         if ($this->Users->save($user)) {
             if ($hasImage) {

--- a/src/Database/Type/EncodedFileType.php
+++ b/src/Database/Type/EncodedFileType.php
@@ -7,11 +7,11 @@ use InvalidArgumentException;
 use PDO;
 
 /**
- * Base64 Encoded image type converter.
+ * Base64 Encoded file type converter.
  *
- * Use to convert base64 eoncoded image data between PHP and the database types.
+ * Use to convert base64 eoncoded file data between PHP and the database types.
  */
-class EncodedImageType extends Type
+class EncodedFileType extends Type
 {
     /**
      * {@inheritDoc}
@@ -19,15 +19,15 @@ class EncodedImageType extends Type
     public function toDatabase($value, Driver $driver)
     {
         if (! is_array($value)) {
-            throw new InvalidArgumentException('Encoded image value must be an array');
+            throw new InvalidArgumentException('Encoded file value must be an array');
         }
 
         if (! isset($value['type'])) {
-            throw new InvalidArgumentException('Encoded image "type" is not defined');
+            throw new InvalidArgumentException('Encoded file "type" is not defined');
         }
 
         if (! isset($value['tmp_name'])) {
-            throw new InvalidArgumentException('Encoded image "tmp_name" is not defined');
+            throw new InvalidArgumentException('Encoded file "tmp_name" is not defined');
         }
 
         return sprintf('data:%s;base64,%s', $value['type'], base64_encode(file_get_contents($value['tmp_name'])));

--- a/src/Database/Type/EncodedImageType.php
+++ b/src/Database/Type/EncodedImageType.php
@@ -1,0 +1,63 @@
+<?php
+namespace App\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\Type;
+use InvalidArgumentException;
+use PDO;
+
+/**
+ * Base64 Encoded image type converter.
+ *
+ * Use to convert base64 eoncoded image data between PHP and the database types.
+ */
+class EncodedImageType extends Type
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function toDatabase($value, Driver $driver)
+    {
+        if (! is_array($value)) {
+            throw new InvalidArgumentException('Encoded image value must be an array');
+        }
+
+        if (! isset($value['type'])) {
+            throw new InvalidArgumentException('Encoded image "type" is not defined');
+        }
+
+        if (! isset($value['tmp_name'])) {
+            throw new InvalidArgumentException('Encoded image "tmp_name" is not defined');
+        }
+
+        return sprintf('data:%s;base64,%s', $value['type'], base64_encode(file_get_contents($value['tmp_name'])));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toPHP($value, Driver $driver)
+    {
+        if (is_resource($value)) {
+            return stream_get_contents($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toStatement($value, Driver $driver)
+    {
+        return PDO::PARAM_STR;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function marshal($value)
+    {
+        return $value;
+    }
+}

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -9,7 +9,7 @@ class User extends BaseUser
     /**
      * @var $_virtual - make virtual fields visible to export to JSON or array
      */
-    protected $_virtual = ['name', 'image'];
+    protected $_virtual = ['name', 'image', 'image_src'];
 
     /**
      * Virtual Field: name
@@ -28,6 +28,20 @@ class User extends BaseUser
         }
 
         return $result;
+    }
+
+    /**
+     * Virtual field image_src accessor.
+     *
+     * @return string
+     */
+    protected function _getImageSrc()
+    {
+        if (Configure::read('Users.gravatar.active') && $this->get('email')) {
+            return $this->getGravatar($this->get('email'));
+        }
+
+        return $this->get('image');
     }
 
     /**

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -46,16 +46,6 @@ class User extends BaseUser
         }
 
         return '/img/user-image-160x160.png';
-    }
 
-    /**
-     * Gravatar getter.
-     *
-     * @param string $email User email
-     * @return string
-     */
-    private function getGravatar($email)
-    {
-        return sprintf('https://www.gravatar.com/avatar/%s?s=160&d=mm&r=g', md5(strtolower(trim($email))));
     }
 }

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Model\Entity;
 
+use App\Avatar\Service as AvatarService;
+use App\Avatar\Type\ImageSource;
 use CakeDC\Users\Model\Entity\User as BaseUser;
 use Cake\Core\Configure;
 
@@ -37,15 +39,19 @@ class User extends BaseUser
      */
     protected function _getImageSrc()
     {
-        if (Configure::read('Users.gravatar.active') && $this->get('email')) {
-            return $this->getGravatar($this->get('email'));
+        $type = Configure::read('Users.avatar.type') ?: ImageSource::class;
+        $options = (array)Configure::read('Users.avatar.options');
+
+        if ($this->get('email')) {
+            $options['{{email}}'] = $this->get('email');
         }
 
         if ($this->get('image')) {
-            return $this->get('image');
+            $options['{{src}}'] = $this->get('image');
         }
 
-        return '/img/user-image-160x160.png';
+        $service = new AvatarService(new $type($options));
 
+        return $service->getImage();
     }
 }

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -9,7 +9,7 @@ class User extends BaseUser
     /**
      * @var $_virtual - make virtual fields visible to export to JSON or array
      */
-    protected $_virtual = ['name', 'image', 'image_src'];
+    protected $_virtual = ['name', 'image_src'];
 
     /**
      * Virtual Field: name

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -41,7 +41,11 @@ class User extends BaseUser
             return $this->getGravatar($this->get('email'));
         }
 
-        return $this->get('image');
+        if ($this->get('image')) {
+            return $this->get('image');
+        }
+
+        return '/img/user-image-160x160.png';
     }
 
     /**
@@ -52,6 +56,6 @@ class User extends BaseUser
      */
     private function getGravatar($email)
     {
-        return sprintf('https://www.gravatar.com/avatar/%s?s=150&d=mm&r=g', md5(strtolower(trim($email))));
+        return sprintf('https://www.gravatar.com/avatar/%s?s=160&d=mm&r=g', md5(strtolower(trim($email))));
     }
 }

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -31,27 +31,6 @@ class User extends BaseUser
     }
 
     /**
-     * User image accessor
-     *
-     * Converts image resource into a string.
-     *
-     * @param resource $image Image resource
-     * @return string
-     */
-    protected function _getImage($image)
-    {
-        if (Configure::read('Users.gravatar.active') && $this->get('email')) {
-            return $this->getGravatar($this->get('email'));
-        }
-
-        if (is_resource($image)) {
-            return stream_get_contents($image);
-        }
-
-        return $image;
-    }
-
-    /**
      * Gravatar getter.
      *
      * @param string $email User email

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -2,6 +2,7 @@
 namespace App\Model\Entity;
 
 use CakeDC\Users\Model\Entity\User as BaseUser;
+use Cake\Core\Configure;
 
 class User extends BaseUser
 {
@@ -39,10 +40,25 @@ class User extends BaseUser
      */
     protected function _getImage($image)
     {
+        if (Configure::read('Users.gravatar.active') && $this->get('email')) {
+            return $this->getGravatar($this->get('email'));
+        }
+
         if (is_resource($image)) {
             return stream_get_contents($image);
         }
 
         return $image;
+    }
+
+    /**
+     * Gravatar getter.
+     *
+     * @param string $email User email
+     * @return string
+     */
+    private function getGravatar($email)
+    {
+        return sprintf('https://www.gravatar.com/avatar/%s?s=150&d=mm&r=g', md5(strtolower(trim($email))));
     }
 }

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -34,7 +34,7 @@ class UsersTable extends Table
      */
     protected function _initializeSchema(TableSchema $schema)
     {
-        $schema->columnType('image', 'base64image');
+        $schema->columnType('image', 'base64');
 
         return $schema;
     }

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -2,6 +2,7 @@
 namespace App\Model\Table;
 
 use CakeDC\Users\Model\Table\UsersTable as Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\Validation\Validator;
 use CsvMigrations\ConfigurationTrait;
 use CsvMigrations\FieldTrait;
@@ -26,6 +27,16 @@ class UsersTable extends Table
 
         // set table/module configuration
         $this->setConfig($this->table());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _initializeSchema(TableSchema $schema)
+    {
+        $schema->columnType('image', 'base64image');
+
+        return $schema;
     }
 
     /**

--- a/src/Template/Element/nav-top.ctp
+++ b/src/Template/Element/nav-top.ctp
@@ -13,26 +13,13 @@
             <!-- User Account: style can be found in dropdown.less -->
             <li class="dropdown user user-menu">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                    <?php
-                    if (!empty($user['image'])) {
-                        echo '<img src="' . $user['image'] . '" class="user-image" />';
-                    } else {
-                        echo $this->Html->image('user-image-160x160.png', ['class' => 'user-image']);
-                    }
-                    ?>
+                    <?= $this->Html->tag('img', false, ['src' => $user['image_src'], 'class' => 'user-image']) ?>
                     <span class="hidden-xs"><?= $user['name']; ?></span>
                 </a>
                 <ul class="dropdown-menu">
                     <!-- User image -->
                     <li class="user-header">
-                        <?php
-                        if (!empty($user['image'])) {
-                            echo '<img src="' . $user['image'] . '" class="img-circle" />';
-                        } else {
-                            echo $this->Html->image('user-image-160x160.png', ['class' => 'img-circle']);
-                        }
-                        ?>
-
+                        <?= $this->Html->tag('img', false, ['src' => $user['image_src'], 'class' => 'img-circle']) ?>
                         <p>
                             <?= $user['name']; ?>
                             <small><?= __d('cake', 'Member since') ?> <?= $user['created']->i18nFormat('LLLL yyyy') ?></small>

--- a/src/Template/Plugin/CakeDC/Users/Users/profile.ctp
+++ b/src/Template/Plugin/CakeDC/Users/Users/profile.ctp
@@ -15,15 +15,7 @@ echo $this->Html->script('AdminLTE./plugins/datepicker/bootstrap-datepicker', ['
             <!-- Profile Image -->
             <div class="box box-primary">
                 <div class="box-body box-profile">
-                <?php
-                if (!empty($user['image'])) {
-                    echo '<img src="' . $user['image'] . '" class="profile-user-img img-responsive img-circle" />';
-                } else {
-                    echo $this->Html->image('user-image-160x160.png', [
-                        'class' => 'profile-user-img img-responsive img-circle'
-                    ]);
-                }
-                ?>
+                <?= $this->Html->tag('img', false, ['src' => $user['image_src'], 'class' => 'profile-user-img img-responsive img-circle']) ?>
 
                 <h3 class="profile-username text-center"><?= $user['name']; ?></h3>
 

--- a/tests/TestCase/Avatar/AvatarTest.php
+++ b/tests/TestCase/Avatar/AvatarTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace App\Test\TestCase\Avatar;
+
+use App\Avatar\Service;
+use App\Avatar\Type\Gravatar;
+use App\Avatar\Type\ImageSource;
+use PHPUnit\Framework\TestCase;
+
+class LoggerTest extends TestCase
+{
+    public function testImageSource()
+    {
+        $service = new Service(new ImageSource([]));
+
+        $this->assertEquals('/img/user-image-160x160.png', $service->getImage());
+    }
+
+    public function testImageSourceWithOptions()
+    {
+        $service = new Service(new ImageSource(['{{src}}' => '/img/foo.png']));
+
+        $this->assertEquals('/img/foo.png', $service->getImage());
+    }
+
+    public function testGravatar()
+    {
+        $service = new Service(new Gravatar([]));
+
+        $this->assertEquals(
+            sprintf('https://www.gravatar.com/avatar/%s?size=160&default=mm&rating=g', md5('')),
+            $service->getImage()
+        );
+    }
+
+    public function testGravatarWithOptions()
+    {
+        $options = [
+            '{{email}}' => 'john.smith@company.com',
+            '{{size}}' => 256,
+            '{{default}}' => 'identicon',
+            '{{rating}}' => 'pg'
+        ];
+
+        $service = new Service(new Gravatar($options));
+
+        $this->assertEquals(
+            sprintf(
+                'https://www.gravatar.com/avatar/%s?size=%d&default=%s&rating=%s',
+                md5($options['{{email}}']),
+                $options['{{size}}'],
+                $options['{{default}}'],
+                $options['{{rating}}']
+            ),
+            $service->getImage()
+        );
+    }
+}


### PR DESCRIPTION
Created avatar domain Service with support for `ImageSource` and `Gravatar`.

ImageSource loads the user's system-uploaded image or falls back to a default one if the user has not uploaded any image yet. You do 

Gravatar loads the user's avatar image by email, using the [gravatar](https://en.gravatar.com) API.

To enable Gravatar support you just need the following:

```php
<?php
// config/users.php

return [
    'Users.gravatar' => [
        'type' => 'App\Avatar\Type\Gravatar'
    ]
];
```