### PR TITLE
Api Versions collector moved to cakephp-utils (task #5386)

### DIFF
--- a/src/Routing/ApiRouter.php
+++ b/src/Routing/ApiRouter.php
@@ -5,6 +5,7 @@ use Cake\Core\App;
 use Cake\Filesystem\Folder;
 use Cake\Routing\Router;
 use Cake\Routing\Route\DashedRoute;
+use Qobo\Utils\Utility;
 
 /**
  * ApiRouter Class
@@ -31,67 +32,8 @@ class ApiRouter
      */
     public function __construct()
     {
-        $this->getVersions();
-    }
-
-    /**
-     * Get API Versions based on subdirs
-     *
-     * Setting API version routes in $_versions.
-     *
-     * @return void
-     */
-    public function getVersions()
-    {
         $apiPath = App::path('Controller/Api')[0];
-
-        $dir = new Folder();
-        // get folders in Controller/Api directory
-        $tree = $dir->tree($apiPath, false, 'dir');
-
-        foreach ($tree as $treePath) {
-            if ($treePath === $apiPath) {
-                continue;
-            }
-
-            $path = str_replace($apiPath, '', $treePath);
-
-            preg_match('/V(\d+)\/V(\d+)/', $path, $matches);
-            if (empty($matches)) {
-                continue;
-            }
-
-            unset($matches[0]);
-            $number = implode('.', $matches);
-
-            $this->_versions[] = [
-                'number' => $number,
-                'prefix' => $this->_getApiRoutePrefix($matches),
-                'path' => $this->_getApiRoutePath($number),
-            ];
-        }
-    }
-
-    /**
-     * Get API Route path
-     *
-     * @param string $version of the path
-     * @return string with prefixes api path version.
-     */
-    protected function _getApiRoutePath($version)
-    {
-        return '/api/v' . $version;
-    }
-
-    /**
-     * Get API Route prefix
-     *
-     * @param array $versions that contain subdirs of prefix
-     * @return string with combined API routing.
-     */
-    protected function _getApiRoutePrefix($versions)
-    {
-        return 'api/v' . implode('/v', $versions);
+        $this->_versions = Utility::getApiVersions($apiPath);
     }
 
     /**


### PR DESCRIPTION
For cross-use around the plugins and application,
collecting API versions moved to `qobo/cakephp-utils` plugin