### PR TITLE
Adding App check for migrated API controllers (task #5386)

### DIFF
--- a/tests/TestCase/AppTest.php
+++ b/tests/TestCase/AppTest.php
@@ -4,8 +4,8 @@ namespace App\Test\TestCase;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\TestSuite\TestCase;
 use Cake\Filesystem\Folder;
+use Cake\TestSuite\TestCase;
 
 class AppTest extends TestCase
 {

--- a/tests/TestCase/AppTest.php
+++ b/tests/TestCase/AppTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace App\Test\TestCase;
 
+use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use Cake\Filesystem\Folder;
 
 class AppTest extends TestCase
 {
@@ -36,6 +38,35 @@ class AppTest extends TestCase
             $message = "Plugin $plugin is not loaded but [" . implode(' or ', (array)$config) . "] is true";
             $this->assertEquals($enabled, Plugin::loaded($plugin), $message);
         }
+    }
+
+    /**
+     * Test API files moved to its subdirectories.
+     *
+     * Making sure that with API versioning being
+     * introduced we're not left with not moved
+     * controller files
+     */
+    public function testApiFilesPlacedCorrectly()
+    {
+        $dir = App::path('Controller/Api')[0];
+        $dir = new Folder($dir);
+
+        $contents = $dir->read(true, true);
+        $found = 0;
+
+        // checking for scanned files
+        if (!empty($contents[1])) {
+            foreach ($contents[1] as $file) {
+                if (preg_match('/^(.*)Controller\.php$/', $file, $matches)) {
+                    if (count($matches) > 1) {
+                        $found++;
+                    }
+                }
+            }
+        }
+
+        $this->assertEquals(0, $found, "Check API directory. Not all controllers were moved to corresponding API subdirs");
     }
 
     public function pluginProvider()

--- a/tests/TestCase/AppTest.php
+++ b/tests/TestCase/AppTest.php
@@ -1,10 +1,8 @@
 <?php
 namespace App\Test\TestCase;
 
-use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Filesystem\Folder;
 use Cake\TestSuite\TestCase;
 
 class AppTest extends TestCase
@@ -38,35 +36,6 @@ class AppTest extends TestCase
             $message = "Plugin $plugin is not loaded but [" . implode(' or ', (array)$config) . "] is true";
             $this->assertEquals($enabled, Plugin::loaded($plugin), $message);
         }
-    }
-
-    /**
-     * Test API files moved to its subdirectories.
-     *
-     * Making sure that with API versioning being
-     * introduced we're not left with not moved
-     * controller files
-     */
-    public function testApiFilesPlacedCorrectly()
-    {
-        $dir = App::path('Controller/Api')[0];
-        $dir = new Folder($dir);
-
-        $contents = $dir->read(true, true);
-        $found = 0;
-
-        // checking for scanned files
-        if (!empty($contents[1])) {
-            foreach ($contents[1] as $file) {
-                if (preg_match('/^(.*)Controller\.php$/', $file, $matches)) {
-                    if (count($matches) > 1) {
-                        $found++;
-                    }
-                }
-            }
-        }
-
-        $this->assertEquals(0, $found, "Check API directory. Not all controllers were moved to corresponding API subdirs");
     }
 
     public function pluginProvider()

--- a/tests/TestCase/Controller/Api/ControllerApiTest.php
+++ b/tests/TestCase/Controller/Api/ControllerApiTest.php
@@ -9,19 +9,15 @@ class ControllerApiTest extends TestCase
 {
     public function testApiFilesPlacedCorrectly()
     {
-        $dir = App::path('Controller/Api')[0];
-        $dir = new Folder($dir);
-
-        $contents = $dir->read(true, true);
+        $path = App::path('Controller/Api')[0];
+        $dir = new Folder($path);
         $found = 0;
 
         // checking for scanned files
-        if (!empty($contents[1])) {
-            foreach ($contents[1] as $file) {
-                if (preg_match('/^(.*)Controller\.php$/', $file, $matches)) {
-                    if (count($matches) > 1) {
-                        $found++;
-                    }
+        foreach ($dir->find('^\w+Controller\.php$') as $file) {
+            if (preg_match('/^(.*)Controller\.php$/', $file, $matches)) {
+                if (count($matches) > 1) {
+                    $found++;
                 }
             }
         }

--- a/tests/TestCase/Controller/Api/ControllerApiTest.php
+++ b/tests/TestCase/Controller/Api/ControllerApiTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace App\Test\TestCase\Controller\Api;
+
+use Cake\Core\App;
+use Cake\Filesystem\Folder;
+use Cake\TestSuite\TestCase;
+
+class ControllerApiTest extends TestCase
+{
+    public function testApiFilesPlacedCorrectly()
+    {
+        $dir = App::path('Controller/Api')[0];
+        $dir = new Folder($dir);
+
+        $contents = $dir->read(true, true);
+        $found = 0;
+
+        // checking for scanned files
+        if (!empty($contents[1])) {
+            foreach ($contents[1] as $file) {
+                if (preg_match('/^(.*)Controller\.php$/', $file, $matches)) {
+                    if (count($matches) > 1) {
+                        $found++;
+                    }
+                }
+            }
+        }
+
+        $this->assertEquals(0, $found, "Check API directory. Not all controllers were moved to corresponding API subdirs");
+    }
+}

--- a/tests/TestCase/Controller/Api/ControllerApiTest.php
+++ b/tests/TestCase/Controller/Api/ControllerApiTest.php
@@ -15,11 +15,7 @@ class ControllerApiTest extends TestCase
 
         // checking for scanned files
         foreach ($dir->find('^\w+Controller\.php$') as $file) {
-            if (preg_match('/^(.*)Controller\.php$/', $file, $matches)) {
-                if (count($matches) > 1) {
-                    $found++;
-                }
-            }
+            $found++;
         }
 
         $this->assertEquals(0, $found, "Check API directory. Not all controllers were moved to corresponding API subdirs");


### PR DESCRIPTION
Due to API versioning that use sub directories for Controllers, we should check that all of them were correctly placed in corresponding directories.