### PR TITLE
Avoid tab content jumping on slow tabs (task #5460)

### DIFF
--- a/webroot/js/general.js
+++ b/webroot/js/general.js
@@ -65,6 +65,7 @@
                 Authorization: 'Bearer ' + api_token
             },
             beforeSend: function (xhr) {
+                $('#' + destination).empty();
                 $('#spinner-system-info').show();
             }
         }).then(function (response) {


### PR DESCRIPTION
Clean tab content before inserting spinner on repeated opening
of the slow tabs (like the database one).  This avoids annoying
jumping of the loaded content up and down, as well as showing
both the spinner and previously loaded content in the same tab
at the same time.