### PR TITLE
Refactoring of System Information functionality (task #5473)

### DIFF
--- a/src/SystemInfo/Cake.php
+++ b/src/SystemInfo/Cake.php
@@ -42,10 +42,10 @@ class Cake
     public static function getVersionUrl($version = null)
     {
         if (empty($version)) {
-            $version = self::getVersion();
+            $version = static::getVersion();
         }
 
-        return self::$releasesUrl . $version;
+        return static::$releasesUrl . $version;
     }
 
     /**

--- a/src/SystemInfo/Cake.php
+++ b/src/SystemInfo/Cake.php
@@ -14,6 +14,11 @@ use Cake\Core\Plugin;
 class Cake
 {
     /**
+     * @var string $releasesUrl Base URL to CakePHP releases
+     */
+    protected static $releasesUrl = 'https://github.com/cakephp/cakephp/releases/tag/';
+
+    /**
      * Get CakePHP version
      *
      * @return string
@@ -21,6 +26,26 @@ class Cake
     public static function getVersion()
     {
         return Configure::version();
+    }
+
+    /**
+     * Get CakePHP version URL
+     *
+     * This method returns the URL to the release
+     * notes of a given version.  If the version
+     * is not specified, then the URL to the current
+     * CakePHP version will be returned.
+     *
+     * @param string $version CakePHP version
+     * @return string
+     */
+    public static function getVersionUrl($version = null)
+    {
+        if (empty($version)) {
+            $version = self::getVersion();
+        }
+
+        return self::$releasesUrl . $version;
     }
 
     /**

--- a/src/SystemInfo/Cake.php
+++ b/src/SystemInfo/Cake.php
@@ -1,0 +1,35 @@
+<?php
+namespace App\SystemInfo;
+
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+
+/**
+ * Cake class
+ *
+ * This is a helper class that assists with
+ * fetching a variety of CakePHP information
+ * from the system.
+ */
+class Cake
+{
+    /**
+     * Get CakePHP version
+     *
+     * @return string
+     */
+    public static function getVersion()
+    {
+        return Configure::version();
+    }
+
+    /**
+     * Get the list of loaded CakePHP plugins
+     *
+     * @return array
+     */
+    public static function getLoadedPlugins()
+    {
+        return Plugin::loaded();
+    }
+}

--- a/src/SystemInfo/Composer.php
+++ b/src/SystemInfo/Composer.php
@@ -46,10 +46,7 @@ class Composer
         $result = [];
         foreach ($packages as $package) {
             // Concatenate all fields that we'll be matching against
-            $matchString = $package['name'];
-            if (!empty($package['description'])) {
-                $matchString .= $package['description'];
-            }
+            $matchString = self::getMatchString($package);
             foreach ($matchWords as $word) {
                 if (empty($result[$word])) {
                     $result[$word] = 0;
@@ -57,6 +54,26 @@ class Composer
                 if (preg_match('/' . $word . '/', $matchString)) {
                     $result[$word]++;
                 }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Concatenate matching package fields into a single string
+     *
+     * @param array $package Package data
+     * @return string
+     */
+    protected static function getMatchString(array $package)
+    {
+        $result = '';
+
+        $keys = ['name', 'description'];
+        foreach ($keys as $key) {
+            if (!empty($package[$key])) {
+                $result .= ' ' . $package[$key];
             }
         }
 

--- a/src/SystemInfo/Composer.php
+++ b/src/SystemInfo/Composer.php
@@ -46,7 +46,7 @@ class Composer
         $result = [];
         foreach ($packages as $package) {
             // Concatenate all fields that we'll be matching against
-            $matchString = self::getMatchString($package);
+            $matchString = static::getMatchString($package);
             foreach ($matchWords as $word) {
                 if (empty($result[$word])) {
                     $result[$word] = 0;

--- a/src/SystemInfo/Composer.php
+++ b/src/SystemInfo/Composer.php
@@ -1,0 +1,65 @@
+<?php
+namespace App\SystemInfo;
+
+/**
+ * Composer class
+ *
+ * This is a helper class that assists with
+ * fetching a variety of composer information
+ * from the system.
+ */
+class Composer
+{
+    /**
+     * Get a list of installed composer packages
+     *
+     * @return array
+     */
+    public static function getInstalledPackages()
+    {
+        //
+        // Installed composer libraries (from composer.lock file)
+        //
+        $composerLock = ROOT . DS . 'composer.lock';
+        $composer = null;
+        if (is_readable($composerLock)) {
+            $composer = json_decode(file_get_contents($composerLock), true);
+        }
+        $result = !empty($composer['packages']) ? $composer['packages'] : [];
+
+        return $result;
+    }
+
+    /**
+     * Get a list of match counts
+     *
+     * This method looks in the list of provided composer
+     * packages for the list of provided match words, and
+     * returns the list of counts for each match word.
+     *
+     * @param array $packages Installed composer packages
+     * @param array $matchWords List of words to match
+     * @return array
+     */
+    public static function getMatchCounts(array $packages, array $matchWords)
+    {
+        $result = [];
+        foreach ($packages as $package) {
+            // Concatenate all fields that we'll be matching against
+            $matchString = $package['name'];
+            if (!empty($package['description'])) {
+                $matchString .= $package['description'];
+            }
+            foreach ($matchWords as $word) {
+                if (empty($result[$word])) {
+                    $result[$word] = 0;
+                }
+                if (preg_match('/' . $word . '/', $matchString)) {
+                    $result[$word]++;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/SystemInfo/Database.php
+++ b/src/SystemInfo/Database.php
@@ -39,7 +39,7 @@ class Database
         //
         // Statistics
         //
-        $allTables = self::getAllTables();
+        $allTables = static::getAllTables();
         $skipTables = 0;
         $tableStats = [];
         foreach ($allTables as $table) {

--- a/src/SystemInfo/Database.php
+++ b/src/SystemInfo/Database.php
@@ -1,0 +1,68 @@
+<?php
+namespace App\SystemInfo;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Database class
+ *
+ * This is a helper class that assists with
+ * fetching a variety of database information
+ * from the system.
+ */
+class Database
+{
+    /**
+     * Get all tables
+     *
+     * This method returns a list of all tables found
+     * in the default database connection.
+     *
+     * @return array
+     */
+    public static function getAllTables()
+    {
+        return ConnectionManager::get('default')->schemaCollection()->listTables();
+    }
+
+    /**
+     * Get table stats
+     *
+     * This method returns a variety of stats, such as
+     * the count of all records, deleted records, etc.
+     *
+     * @return array
+     */
+    public static function getTableStats()
+    {
+        //
+        // Statistics
+        //
+        $allTables = self::getAllTables();
+        $skipTables = 0;
+        $tableStats = [];
+        foreach ($allTables as $table) {
+            // Skip phinx database schema version tables
+            if (preg_match('/phinxlog/', $table)) {
+                $skipTables++;
+                continue;
+            }
+            // Bypassing any CakePHP logic for permissions, pagination, and so on,
+            // and executing raw query to get reliable data.
+            $sth = ConnectionManager::get('default')->execute("SELECT COUNT(*) AS total FROM `$table`");
+            $result = $sth->fetch('assoc');
+            $tableStats[$table]['total'] = $result['total'];
+
+            $tableInstance = TableRegistry::get($table);
+            $tableStats[$table]['deleted'] = 0;
+            if ($tableInstance->hasField('trashed')) {
+                $sth = ConnectionManager::get('default')->execute("SELECT COUNT(*) AS deleted FROM `$table` WHERE `trashed` IS NOT NULL AND `trashed` <> '0000-00-00 00:00:00'");
+                $result = $sth->fetch('assoc');
+                $tableStats[$table]['deleted'] = $result['deleted'];
+            }
+        }
+
+        return [$skipTables, $tableStats];
+    }
+}

--- a/src/SystemInfo/Git.php
+++ b/src/SystemInfo/Git.php
@@ -1,0 +1,71 @@
+<?php
+namespace App\SystemInfo;
+
+use RuntimeException;
+
+/**
+ * Git class
+ *
+ * This is a helper class that assists with
+ * fetching a variety of git information
+ * from the system.
+ */
+class Git
+{
+    /**
+     * @var array $commands Git command shortcodes
+     */
+    protected static $commands = [
+        'localChanges' => 'git status --porcelain',
+        'currentHash' => 'git rev-parse --short HEAD',
+    ];
+
+    /**
+     * Get command line and arguments for a given command
+     *
+     * @throws \RuntimeException when the command is not defined
+     * @param string $command Git command to expand
+     * @return string
+     */
+    public static function getCommand($command)
+    {
+        if (empty(self::$commands[$command])) {
+            throw new RuntimeException("Git command [$command] is not defined");
+        }
+
+        return self::$commands[$command];
+    }
+
+    /**
+     * Get local changes
+     *
+     * @return array
+     */
+    public static function getLocalChanges()
+    {
+        $result = [];
+
+        $command = self::getCommand('localChanges');
+
+        $changes = trim(shell_exec($command));
+        if (empty($changes)) {
+            return $result;
+        }
+
+        $result = explode("\n", $changes);
+
+        return $result;
+    }
+
+    /**
+     * Get the last commit short hash
+     *
+     * @return string
+     */
+    public static function getCurrentHash()
+    {
+        $command = self::getCommand('currentHash');
+
+        return (string)shell_exec($command);
+    }
+}

--- a/src/SystemInfo/Git.php
+++ b/src/SystemInfo/Git.php
@@ -29,11 +29,11 @@ class Git
      */
     public static function getCommand($command)
     {
-        if (empty(self::$commands[$command])) {
+        if (empty(static::$commands[$command])) {
             throw new RuntimeException("Git command [$command] is not defined");
         }
 
-        return self::$commands[$command];
+        return static::$commands[$command];
     }
 
     /**
@@ -45,7 +45,7 @@ class Git
     {
         $result = [];
 
-        $command = self::getCommand('localChanges');
+        $command = static::getCommand('localChanges');
 
         $changes = trim(shell_exec($command));
         if (empty($changes)) {
@@ -64,7 +64,7 @@ class Git
      */
     public static function getCurrentHash()
     {
-        $command = self::getCommand('currentHash');
+        $command = static::getCommand('currentHash');
 
         return (string)shell_exec($command);
     }

--- a/src/SystemInfo/Php.php
+++ b/src/SystemInfo/Php.php
@@ -2,6 +2,7 @@
 namespace App\SystemInfo;
 
 use InvalidArgumentException;
+use Qobo\Utils\Utility;
 
 /**
  * Php class
@@ -110,40 +111,6 @@ class Php
     }
 
     /**
-     * Convert value to bytes
-     *
-     * Convert sizes from PHP settings like post_max_size
-     * for example 8M to integer number of bytes.
-     *
-     * If number is integer return as is.
-     *
-     * NOTE: This is a modified copy from qobo/cakephp-utils/config/bootstrap.php
-     *
-     * @throws \InvalidArgumentException when cannot convert
-     * @param string|int $value Value to convert
-     * @return int
-     */
-    public static function valueToBytes($value)
-    {
-        if (is_int($value)) {
-            return $value;
-        }
-
-        $result = (string)$value;
-        if (preg_match('/(\d+)K/i', $result, $matches)) {
-            $result = $matches[1] * 1024;
-        } elseif (preg_match('/(\d+)M/i', $result, $matches)) {
-            $result = $matches[1] * 1024 * 1024;
-        } elseif (preg_match('/(\d+)G/i', $result, $matches)) {
-            $result = $matches[1] * 1024 * 1024 * 1024;
-        } else {
-            throw new InvalidArgumentException("Failed to find K, M, or G in a non-integer value [$result]");
-        }
-
-        return (int)$result;
-    }
-
-    /**
      * Get configuration setting for memory_limit
      *
      * @return int Memory limit in bytes
@@ -151,7 +118,7 @@ class Php
     public static function getMemoryLimit()
     {
         $result = static::getIniValue('memory_limit');
-        $result = static::valueToBytes($result);
+        $result = Utility::valueToBytes($result);
 
         return $result;
     }
@@ -174,7 +141,7 @@ class Php
     public static function getUploadMaxFilesize()
     {
         $result = static::getIniValue('upload_max_filesize');
-        $result = static::valueToBytes($result);
+        $result = Utility::valueToBytes($result);
 
         return $result;
     }
@@ -187,7 +154,7 @@ class Php
     public static function getPostMaxSize()
     {
         $result = static::getIniValue('post_max_size');
-        $result = static::valueToBytes($result);
+        $result = Utility::valueToBytes($result);
 
         return $result;
     }

--- a/src/SystemInfo/Php.php
+++ b/src/SystemInfo/Php.php
@@ -1,0 +1,194 @@
+<?php
+namespace App\SystemInfo;
+
+use InvalidArgumentException;
+
+/**
+ * Php class
+ *
+ * This is a helper class that assists with
+ * fetching a variety of PHP information
+ * from the system.
+ */
+class Php
+{
+    /**
+     * Get current version of PHP or provided extension
+     *
+     * @param string $extension Optional extension, like 'curl'
+     * @return string
+     */
+    public static function getVersion($extension = null)
+    {
+        return $extension ? phpversion($extension) : phpversion();
+    }
+
+    /**
+     * Get current SAPI
+     *
+     * @return string
+     */
+    public static function getSapi()
+    {
+        return PHP_SAPI;
+    }
+
+    /**
+     * Get a list of loaded PHP extensions
+     *
+     * @return array
+     */
+    public static function getLoadedExtensions()
+    {
+        $result = [];
+
+        $extensions = get_loaded_extensions();
+        asort($extensions);
+
+        foreach ($extensions as $extension) {
+            $result[$extension] = static::getVersion($extension);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get current user
+     *
+     * This method returns the user which runs
+     * the current PHP process.
+     *
+     * @return string
+     */
+    public static function getUser()
+    {
+        return get_current_user();
+    }
+
+    /**
+     * Get path to PHP executable
+     *
+     * This method returns the path to the PHP
+     * executable used to run the current script.
+     * This can be PHP FPM, CLI, or a variety of
+     * other options.
+     *
+     * @return string
+     */
+    public static function getBinary()
+    {
+        return PHP_BINARY;
+    }
+
+    /**
+     * Get path to php.ini
+     *
+     * This method returns the full path to the
+     * php.ini file which was used for the
+     * current process.
+     *
+     * @return string
+     */
+    public static function getIniPath()
+    {
+        return php_ini_loaded_file();
+    }
+
+    /**
+     * Get configuration value
+     *
+     * This method returns the value of the
+     * given configuration key from the
+     * php.ini.
+     *
+     * @param sting $configKey Configuration key to get the value for
+     * @return mixed
+     */
+    public static function getIniValue($configKey)
+    {
+        return ini_get((string)$configKey);
+    }
+
+    /**
+     * Convert value to bytes
+     *
+     * Convert sizes from PHP settings like post_max_size
+     * for example 8M to integer number of bytes.
+     *
+     * If number is integer return as is.
+     *
+     * NOTE: This is a modified copy from qobo/cakephp-utils/config/bootstrap.php
+     *
+     * @throws \InvalidArgumentException when cannot convert
+     * @param string|int $value Value to convert
+     * @return int
+     */
+    public static function valueToBytes($value)
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        $result = (string)$value;
+        if (preg_match('/(\d+)K/i', $result, $matches)) {
+            $result = $matches[1] * 1024;
+        } elseif (preg_match('/(\d+)M/i', $result, $matches)) {
+            $result = $matches[1] * 1024 * 1024;
+        } elseif (preg_match('/(\d+)G/i', $result, $matches)) {
+            $result = $matches[1] * 1024 * 1024 * 1024;
+        } else {
+            throw new InvalidArgumentException("Failed to find K, M, or G in a non-integer value [$result]");
+        }
+
+        return (int)$result;
+    }
+
+    /**
+     * Get configuration setting for memory_limit
+     *
+     * @return int Memory limit in bytes
+     */
+    public static function getMemoryLimit()
+    {
+        $result = static::getIniValue('memory_limit');
+        $result = static::valueToBytes($result);
+
+        return $result;
+    }
+
+    /**
+     * Get configuration setting for max_execution_time
+     *
+     * @return numeric Maximum execution time in seconds
+     */
+    public static function getMaxExecutionTime()
+    {
+        return static::getIniValue('max_execution_time');
+    }
+
+    /**
+     * Get configuration setting for upload_max_filesize
+     *
+     * @return int Maximum upload file size in bytes
+     */
+    public static function getUploadMaxFilesize()
+    {
+        $result = static::getIniValue('upload_max_filesize');
+        $result = static::valueToBytes($result);
+
+        return $result;
+    }
+
+    /**
+     * Get configuration setting for post_max_size
+     *
+     * @return int Max post size in bytes
+     */
+    public static function getPostMaxSize()
+    {
+        $result = static::getIniValue('post_max_size');
+        $result = static::valueToBytes($result);
+
+        return $result;
+    }
+}

--- a/src/SystemInfo/Project.php
+++ b/src/SystemInfo/Project.php
@@ -50,7 +50,7 @@ class Project
      */
     public static function getUrl()
     {
-        $result = self::$defaultUrl;
+        $result = static::$defaultUrl;
 
         $url = getenv('PROJECT_URL');
         if (!empty($url)) {
@@ -80,7 +80,7 @@ class Project
      */
     public static function getDisplayVersion()
     {
-        $result = self::$defaultVersion;
+        $result = static::$defaultVersion;
 
         $version = getenv('PROJECT_VERSION');
         if (!empty($version)) {
@@ -130,7 +130,7 @@ class Project
             'previous' => ROOT . DS . 'build' . DS . 'version.bak',
         ];
         foreach ($versions as $version => $file) {
-            $result[$version] = self::$defaultVersion;
+            $result[$version] = static::$defaultVersion;
             if (is_readable($file)) {
                 $result[$version] = file_get_contents($file);
             }
@@ -160,7 +160,7 @@ class Project
      */
     public static function getCopyright()
     {
-        $result = 'Copyright &copy; ' . date('Y') . ' ' . self::getName() . '. All rights reserved.';
+        $result = 'Copyright &copy; ' . date('Y') . ' ' . static::getName() . '. All rights reserved.';
 
         return $result;
     }

--- a/src/SystemInfo/Project.php
+++ b/src/SystemInfo/Project.php
@@ -48,7 +48,7 @@ class Project
      *
      * @return string
      */
-    public function getUrl()
+    public static function getUrl()
     {
         $result = self::$defaultUrl;
 
@@ -158,7 +158,7 @@ class Project
      *
      * @return string
      */
-    public function getCopyright()
+    public static function getCopyright()
     {
         $result = 'Copyright &copy; ' . date('Y') . ' ' . self::getName() . '. All rights reserved.';
 

--- a/src/SystemInfo/Project.php
+++ b/src/SystemInfo/Project.php
@@ -1,0 +1,167 @@
+<?php
+namespace App\SystemInfo;
+
+use Cake\Core\Configure;
+use Cake\Routing\Router;
+
+/**
+ * Project class
+ *
+ * This is a helper class that assists with
+ * fetching a variety of project information
+ * from the system.
+ */
+class Project
+{
+    /**
+     * @var string $defaultVersion Version string fallback
+     */
+    protected static $defaultVersion = 'N/A';
+
+    /**
+     * @var string $defaultUrl Url string fallback
+     */
+    protected static $defaultUrl = 'https://github.com/QoboLtd/project-template-cakephp';
+
+    /**
+     * Get project name
+     *
+     * This method returns a human-friendly (if
+     * possible) project name for showing to users
+     * in the footer, email, etc.
+     *
+     * @return string project name
+     */
+    public static function getName()
+    {
+        // Use PROJECT_NAME environment variable or project folder name
+        $projectName = getenv('PROJECT_NAME') ?: basename(ROOT);
+
+        return $projectName;
+    }
+
+    /**
+     * Get project URL
+     *
+     * This method returns the root URL of the
+     * project.
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        $result = self::$defaultUrl;
+
+        $url = getenv('PROJECT_URL');
+        if (!empty($url)) {
+            return $url;
+        }
+
+        $url = Router::fullBaseUrl();
+        if (!empty($url)) {
+            return $url;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get project version for display purposes
+     *
+     * This method returns a human-friendly (if
+     * possible) version of the system for showing
+     * to users in the footer, emails, etc.
+     *
+     * The versions are read from a variety of sources
+     * like environment variables, git history, etc.,
+     * with a fallback on a pre-defined value.
+     *
+     * @return string
+     */
+    public static function getDisplayVersion()
+    {
+        $result = self::$defaultVersion;
+
+        $version = getenv('PROJECT_VERSION');
+        if (!empty($version)) {
+            return $version;
+        }
+
+        $version = getenv('API_PROJECT_VERSION');
+        if (!empty($version)) {
+            return $version;
+        }
+
+        $version = getenv('GIT_BRANCH');
+        if (!empty($version)) {
+            return $version;
+        }
+
+        $version = Git::getCurrentHash();
+        if (!empty($version)) {
+            return $version;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get build versions
+     *
+     * Return a list of build versions, including the following:
+     *
+     * * current - the latest attempted build version
+     * * deployed - the latest successful build version
+     * * previous - the previously attempted build version
+     *
+     * If any of the build versions is not known, the pre-defined
+     * default is returned instead.
+     *
+     * @return array
+     */
+    public static function getBuildVersions()
+    {
+        $result = [];
+
+        // Read build/version* files or use N/A as fallback
+        $versions = [
+            'current' => ROOT . DS . 'build' . DS . 'version',
+            'deployed' => ROOT . DS . 'build' . DS . 'version.ok',
+            'previous' => ROOT . DS . 'build' . DS . 'version.bak',
+        ];
+        foreach ($versions as $version => $file) {
+            $result[$version] = self::$defaultVersion;
+            if (is_readable($file)) {
+                $result[$version] = file_get_contents($file);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     *  Get project logo
+     *
+     * @param string $logoSize of logo - mini or large
+     * @return string base64 encoded project logo
+     */
+    public static function getLogo($logoSize = '')
+    {
+        $logoSize = $logoSize ?: 'mini';
+        $logo = Configure::read('Theme.logo.' . $logoSize);
+
+        return $logo;
+    }
+
+    /**
+     * Get project copyright
+     *
+     * @return string
+     */
+    public function getCopyright()
+    {
+        $result = 'Copyright &copy; ' . date('Y') . ' ' . self::getName() . '. All rights reserved.';
+
+        return $result;
+    }
+}

--- a/src/SystemInfo/Server.php
+++ b/src/SystemInfo/Server.php
@@ -23,10 +23,10 @@ class Server
     {
         $result = [
             'Hostname' => gethostname(),
-            'Operating System' => self::getOperatingSystem(),
-            'Machine Type' => self::getMachineType(),
-            'Number of CPUs' => self::getNumberOfCpus(),
-            'Total RAM' => self::getTotalRam(),
+            'Operating System' => static::getOperatingSystem(),
+            'Machine Type' => static::getMachineType(),
+            'Number of CPUs' => static::getNumberOfCpus(),
+            'Total RAM' => static::getTotalRam(),
         ];
 
         return $result;

--- a/src/SystemInfo/Server.php
+++ b/src/SystemInfo/Server.php
@@ -75,7 +75,7 @@ class Server
      *
      * @return string
      */
-    public function getTotalRam()
+    public static function getTotalRam()
     {
         $result = 'N/A';
         $memoryInfoFile = '/proc/meminfo';

--- a/src/SystemInfo/Server.php
+++ b/src/SystemInfo/Server.php
@@ -1,0 +1,91 @@
+<?php
+namespace App\SystemInfo;
+
+/**
+ * Server class
+ *
+ * This is a helper class that assists with
+ * fetching a variety of server information
+ * from the system.
+ */
+class Server
+{
+    /**
+     * Get server information
+     *
+     * This method returns a number of
+     * human-friendly metrics and facts about
+     * the server.
+     *
+     * @return array
+     */
+    public static function getInfo()
+    {
+        $result = [
+            'Hostname' => gethostname(),
+            'Operating System' => self::getOperatingSystem(),
+            'Machine Type' => self::getMachineType(),
+            'Number of CPUs' => self::getNumberOfCpus(),
+            'Total RAM' => self::getTotalRam(),
+        ];
+
+        return $result;
+    }
+
+    /**
+     * Get server operating system name and release
+     *
+     * @return string
+     */
+    public static function getOperatingSystem()
+    {
+        return php_uname('s') . ' ' . php_uname('r');
+    }
+
+    /**
+     * Get server machine type / hardware architecture
+     *
+     * @return string
+     */
+    public static function getMachineType()
+    {
+        return php_uname('m');
+    }
+
+    /**
+     * Get server CPU count
+     *
+     * @return int
+     */
+    public static function getNumberOfCpus()
+    {
+        $result = 0;
+        $cpuInfoFile = '/proc/cpuinfo';
+        if (is_file($cpuInfoFile) && is_readable($cpuInfoFile)) {
+            $cpuInfoFile = file($cpuInfoFile);
+            $cpus = preg_grep("/^processor/", $cpuInfoFile);
+            $result = count($cpus);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get server total RAM size
+     *
+     * @return string
+     */
+    public function getTotalRam()
+    {
+        $result = 'N/A';
+        $memoryInfoFile = '/proc/meminfo';
+        if (is_file($memoryInfoFile) && is_readable($memoryInfoFile)) {
+            $memoryInfoFile = file($memoryInfoFile);
+            $totalMemory = preg_grep("/^MemTotal:/", $memoryInfoFile);
+            list($key, $size, $unit) = preg_split('/\s+/', $totalMemory[0], 3);
+            $result = number_format($size) . ' ' . $unit;
+        }
+
+        return $result;
+    }
+}

--- a/src/Template/Element/System/about.ctp
+++ b/src/Template/Element/System/about.ctp
@@ -1,0 +1,21 @@
+<?php
+//
+// About project section
+//
+
+use App\SystemInfo\Project;
+
+$projectName = Project::getName();
+$projectVersion = Project::getDisplayVersion();
+$projectLogo = Project::getLogo('large');
+
+?>
+<div class="box box-primary">
+    <div class="box-header with-border">
+        <h3 class="box-title">About <?= $projectName ?></h3>
+    </div>
+    <div class="box-body">
+        <p><?= $projectLogo ?></p>
+        <p>Welcome to <b><?= $projectName ?></b>.  You are using version <b><?= $projectVersion ?></b>.
+    </div>
+</div>

--- a/src/Template/Element/System/cakephp.ctp
+++ b/src/Template/Element/System/cakephp.ctp
@@ -1,29 +1,52 @@
 <?php
-$plugins = $this->SystemInfo->getCakePhpPlugins();
+//
+// CakePHP information
+//
+
+use App\SystemInfo\Cake;
+
+$cakeVersion = Cake::getVersion();
+$cakeVersionUrl = Cake::getVersionUrl();
+
+$plugins = Cake::getLoadedPlugins();
+
 ?>
 <div class="row">
     <div class="col-md-3">
-        <div class="info-box">
-            <span class="info-box-icon bg-blue"><i class="fa fa-birthday-cake"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">CakePHP version</span>
-                <span class="info-box-number"><?= $this->SystemInfo->getCakePhpVersion() ?></span>
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Summary</h3>
             </div>
-        </div>
-        <div class="info-box">
-            <span class="info-box-icon bg-blue"><i class="fa fa-plug"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">CakePHP plugins</span>
-                <span class="info-box-number"><?= number_format(count($plugins)); ?></span>
+            <div class="box-body">
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-birthday-cake"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">CakePHP version</span>
+                        <span class="info-box-number"><?= $this->Html->link($cakeVersion, $cakeVersionUrl, ['target' => '_blank']) ?></span>
+                    </div>
+                </div>
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-plug"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">CakePHP plugins</span>
+                        <span class="info-box-number"><?= number_format(count($plugins)); ?></span>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
-    <div class="col-md-9">
-        <b>Loaded plugins:</b>
-        <ul>
-        <?php foreach ($plugins as $plugin) : ?>
-            <li><?= $plugin ?></li>
-        <?php endforeach; ?>
-        </ul>
+    <div class="col-md-3">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Loaded Plugins</h3>
+            </div>
+            <div class="box-body">
+                <ul>
+                <?php foreach ($plugins as $plugin) : ?>
+                    <li><?= $plugin ?></li>
+                <?php endforeach; ?>
+                </ul>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/Template/Element/System/composer.ctp
+++ b/src/Template/Element/System/composer.ctp
@@ -1,5 +1,11 @@
 <?php
-$packages = $this->SystemInfo->getComposerPackages();
+//
+// Composer information
+//
+
+use App\SystemInfo\Composer;
+
+$packages = Composer::getInstalledPackages();
 $count = count($packages);
 
 // Words to match in composer libraries and the icon to use
@@ -9,66 +15,74 @@ $matches = [
     'qobo' => 'copyright'
 ];
 $matchWords = array_keys($matches);
-$matchCounts = $this->SystemInfo->getComposerMatchCounts($packages, $matchWords);
+$matchCounts = Composer::getMatchCounts($packages, $matchWords);
 
-// Info boxes go into separate columns.  The width of each column depends on the
-// number of matched words we use, plus one for the total count of packages.
-$columnWidth = (int)floor(12 / (count($matchWords) + 1));
 ?>
 <div class="row">
-    <div class="col-md-<?= $columnWidth ?>">
-        <div class="info-box">
-            <span class="info-box-icon bg-blue"><i class="fa fa-book"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">Composer libraries</span>
-                <span class="info-box-number"><?php echo number_format($count); ?></span>
+    <div class="col-md-3">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Composer Summary</h3>
+            </div>
+            <div class="box-body">
+
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-book"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Composer libraries</span>
+                        <span class="info-box-number"><?php echo number_format($count); ?></span>
+                    </div>
+                </div>
+                <?php foreach ($matchCounts as $word => $count) : ?>
+                    <div class="info-box">
+                        <span class="info-box-icon bg-blue"><i class="fa fa-<?= $matches[$word] ?>"></i></span>
+                        <div class="info-box-content">
+                            <span class="info-box-text">Match <?php echo $word; ?></span>
+                            <span class="info-box-number"><?php echo number_format($count); ?></span>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
             </div>
         </div>
     </div>
-    <?php foreach ($matchCounts as $word => $count) : ?>
-        <div class="col-md-<?= $columnWidth ?>">
-            <div class="info-box">
-                <span class="info-box-icon bg-blue"><i class="fa fa-<?= $matches[$word] ?>"></i></span>
-                <div class="info-box-content">
-                    <span class="info-box-text">Match <?php echo $word; ?></span>
-                    <span class="info-box-number"><?php echo number_format($count); ?></span>
-                </div>
-            </div>
-        </div>
-    <?php endforeach; ?>
-</div>
-<div class="row">
-    <div class="col-md-12">
+    <div class="col-md-9">
         <?php if (0 < $count) : ?>
-            <table class="table table-hover table-condensed table-vertical-align">
-                <thead>
-                    <tr>
-                        <th width="20%">Name</th>
-                        <th width="10%">Version</th>
-                        <th width="10%">License</th>
-                        <th width="60%">Description</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($packages as $package) : ?>
-                        <?php
-                            $url = '';
-                            if (!empty($package['homepage'])) {
-                                $url = $package['homepage'];
-                            }
-                            if (empty($url) && !empty($package['source']['url'])) {
-                                $url = $package['source']['url'];
-                            }
-                        ?>
+
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Installed Dependencies</h3>
+            </div>
+            <div class="box-body">
+                <table class="table table-hover table-condensed table-vertical-align">
+                    <thead>
                         <tr>
-                            <td><?= empty($url) ? $package['name'] : $this->Html->link($package['name'], $url, ['target' => '_blank']); ?></td>
-                            <td><?= $package['version'] ?></td>
-                            <td><?= implode(', ', $package['license']); ?></td>
-                            <td><?= empty($package['description']) ? '&nbsp;' : $package['description'] ?></td>
+                            <th width="20%">Name</th>
+                            <th width="10%">Version</th>
+                            <th width="10%">License</th>
+                            <th width="60%">Description</th>
                         </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($packages as $package) : ?>
+                            <?php
+                                $url = '';
+                                if (!empty($package['homepage'])) {
+                                    $url = $package['homepage'];
+                                }
+                                if (empty($url) && !empty($package['source']['url'])) {
+                                    $url = $package['source']['url'];
+                                }
+                            ?>
+                            <tr>
+                                <td><?= empty($url) ? $package['name'] : $this->Html->link($package['name'], $url, ['target' => '_blank']); ?></td>
+                                <td><?= $package['version'] ?></td>
+                                <td><?= implode(', ', $package['license']); ?></td>
+                                <td><?= empty($package['description']) ? '&nbsp;' : $package['description'] ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         <?php endif; ?>
     </div>
 </div>

--- a/src/Template/Element/System/database.ctp
+++ b/src/Template/Element/System/database.ctp
@@ -1,26 +1,42 @@
 <?php
+//
+// Database information
+//
 
-$allTables = $this->SystemInfo->getAllTables();
-list($skipTables, $tableStats) = $this->SystemInfo->getTableStats();
+use App\SystemInfo\Database;
+
+$allTables = Database::getAllTables();
+list($skipTables, $tableStats) = Database::getTableStats();
+
 ?>
 <div class="row">
-    <div class="col-md-3">
-        <div class="info-box bg-blue">
-            <span class="info-box-icon"><i class="fa fa-database"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">Total tables</span>
-                <span class="info-box-number"><?php echo number_format(count($allTables)); ?></span>
-                <div class="progress">
-                    <div class="progress-bar" style="width: <?php echo $this->SystemInfo->getProgressValue($skipTables, count($allTables)); ?>"></div>
+    <div class="col-md-4">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Database Summary</h3>
+            </div>
+            <div class="box-body">
+                <div class="info-box bg-blue">
+                    <span class="info-box-icon"><i class="fa fa-database"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Total tables</span>
+                        <span class="info-box-number"><?php echo number_format(count($allTables)); ?></span>
+                        <div class="progress">
+                            <div class="progress-bar" style="width: <?php echo $this->SystemInfo->getProgressValue($skipTables, count($allTables)); ?>"></div>
+                        </div>
+                        <span class="progress-description"><?php echo $skipTables; ?> system tables</span>
+                    </div>
                 </div>
-                <span class="progress-description"><?php echo $skipTables; ?> system tables</span>
             </div>
         </div>
     </div>
-    <div class="col-md-9">
-        <div class="row">
-            <?php foreach ($tableStats as $table => $counts) : ?>
-                <div class="col-md-6">
+    <div class="col-md-4">
+        <div class="box box-info">
+            <div class="box-header with-border">
+                <h3 class="box-title">Table Records</h3>
+            </div>
+            <div class="box-body">
+                <?php foreach ($tableStats as $table => $counts) : ?>
                     <div class="info-box bg-aqua">
                         <span class="info-box-icon"><i class="fa fa-table"></i></span>
                         <div class="info-box-content">
@@ -34,8 +50,8 @@ list($skipTables, $tableStats) = $this->SystemInfo->getTableStats();
                             </span>
                         </div>
                     </div>
-                </div>
-            <?php endforeach; ?>
+                <?php endforeach; ?>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Template/Element/System/developer.ctp
+++ b/src/Template/Element/System/developer.ctp
@@ -1,35 +1,88 @@
 <?php
+//
+// Developer information
+//
 
-$localModificationsCommand = $this->SystemInfo->getLocalModificationsCommand();
-$localModifications = $this->SystemInfo->getLocalModifications();
+use App\SystemInfo\Project;
+use App\SystemInfo\Git;
+
+$currentVersion = Project::getDisplayVersion();
+$buildVersions = Project::getBuildVersions();
+
+$localChangesCommand = Git::getCommand('localChanges');
+$localChanges = Git::getLocalChanges();
+
+$localChangesOutput = "<b>$ " . $localChangesCommand . "</b>\n\n";
+$localChangesOutput .= !empty($localChanges) ? implode("\n", $localChanges) : "All good, no local modifications found.";
+
 ?>
 <div class="row">
     <div class="col-md-3">
-        <div class="info-box">
-        <?php if (empty($localModifications)) : ?>
-            <span class="info-box-icon bg-green"><i class="fa fa-thumbs-up"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">Local modifications</span>
-                <span class="info-box-number">0</span>
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Build Summary</h3>
             </div>
-        <?php else : ?>
-            <span class="info-box-icon bg-red"><i class="fa fa-exclamation-circle"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">Local modifications</span>
-                <span class="info-box-number"><?php echo number_format(count($localModifications)); ?></span>
+            <div class="box-body">
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-tag"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Current version</span>
+                        <span class="info-box-number"><?= $currentVersion; ?></span>
+                    </div>
+                </div>
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-tag"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Current build</span>
+                        <span class="info-box-number"><?= $buildVersions['current']; ?></span>
+                    </div>
+                </div>
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-tag"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Deployed build</span>
+                        <span class="info-box-number"><?= $buildVersions['deployed']; ?></span>
+                    </div>
+                </div>
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-tag"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Previous build</span>
+                        <span class="info-box-number"><?= $buildVersions['previous']; ?></span>
+                    </div>
+                </div>
             </div>
-        <?php endif; ?>
         </div>
     </div>
     <div class="col-md-9">
-        <?php if (!empty($localModifications)) : ?>
-            <pre><?php
-                echo $localModificationsCommand . "\n";
-                echo implode("\n", $localModifications);
-            ?></pre>
-        <?php else : ?>
-            All good, no local modifications found.
-        <?php endif; ?>
-
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Local Changes</h3>
+            </div>
+            <div class="box-body">
+                <div class="row">
+                    <div class="col-md-4">
+                        <div class="info-box">
+                        <?php if (empty($localChanges)) : ?>
+                            <span class="info-box-icon bg-green"><i class="fa fa-thumbs-up"></i></span>
+                            <div class="info-box-content">
+                                <span class="info-box-text">Changed files</span>
+                                <span class="info-box-number">0</span>
+                            </div>
+                        <?php else : ?>
+                            <span class="info-box-icon bg-red"><i class="fa fa-exclamation-circle"></i></span>
+                            <div class="info-box-content">
+                                <span class="info-box-text">Changed files</span>
+                                <span class="info-box-number"><?php echo number_format(count($localChanges)); ?></span>
+                            </div>
+                        <?php endif; ?>
+                        </div>
+                    </div>
+                    <div class="col-md-8">
+                        <pre><?php echo $localChangesOutput; ?></pre>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/Template/Element/System/php.ctp
+++ b/src/Template/Element/System/php.ctp
@@ -2,8 +2,8 @@
 //
 // PHP setup
 //
+
 $setup = [
-    'PHP Version' => PHP_VERSION,
     'Server API' => PHP_SAPI,
     'PHP Server User' => get_current_user(),
     'PHP Binary' => PHP_BINARY,
@@ -22,36 +22,57 @@ asort($extensions);
 ?>
 <div class="row">
     <div class="col-md-3">
-        <div class="info-box">
-            <span class="info-box-icon bg-blue"><i class="fa fa-heart"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">PHP version</span>
-                <span class="info-box-number"><?php echo PHP_VERSION; ?></span>
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">PHP Summary</h3>
             </div>
-        </div>
-        <div class="info-box">
-            <span class="info-box-icon bg-blue"><i class="fa fa-plug"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">PHP extensions</span>
-                <span class="info-box-number"><?php echo number_format(count($extensions)); ?></span>
+            <div class="box-body">
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-heart"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">PHP version</span>
+                        <span class="info-box-number"><?php echo PHP_VERSION; ?></span>
+                    </div>
+                </div>
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-plug"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">PHP extensions</span>
+                        <span class="info-box-number"><?php echo number_format(count($extensions)); ?></span>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
     <div class="col-md-4">
-        <dl class="dl-horizontal">
-        <?php
-            foreach ($setup as $name => $value) {
-                print '<dt>' . $name . ':</dt><dd>' . $value . '</dd>';
-            }
-        ?>
-        </dl>
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">PHP Configuration</h3>
+            </div>
+            <div class="box-body">
+                <dl class="dl-horizontal">
+                <?php
+                    foreach ($setup as $name => $value) {
+                        print '<dt>' . $name . ':</dt><dd>' . $value . '</dd>';
+                    }
+                ?>
+                </dl>
+            </div>
+        </div>
     </div>
     <div class="col-md-5">
-        <b>Loaded extensions:</b>
-        <ul class="list-inline">
-        <?php foreach ($extensions as $extension) : ?>
-            <li><?= $extension ?></li>
-        <?php endforeach; ?>
-        </ul>
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Loaded Extensions</h3>
+            </div>
+            <div class="box-body">
+
+                <ul class="list-inline">
+                <?php foreach ($extensions as $extension) : ?>
+                    <li><?= $extension ?></li>
+                <?php endforeach; ?>
+                </ul>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/Template/Element/System/php.ctp
+++ b/src/Template/Element/System/php.ctp
@@ -3,22 +3,21 @@
 // PHP setup
 //
 
+use App\SystemInfo\Php;
+
 $setup = [
-    'Server API' => PHP_SAPI,
-    'PHP Server User' => get_current_user(),
-    'PHP Binary' => PHP_BINARY,
-    'PHP Configuration File' => php_ini_loaded_file(),
-    'Memory Limit' => ini_get('memory_limit'),
-    'Max Execution Time' => ini_get('max_execution_time') . ' seconds',
-    'Upload Max Filesize' => $this->Number->toReadableSize(sizeToBytes(ini_get('upload_max_filesize'))),
-    'Post Max Size' => $this->Number->toReadableSize(sizeToBytes(ini_get('post_max_size'))),
+    'Server API' => Php::getSapi(),
+    'PHP Server User' => Php::getUser(),
+    'PHP Binary' => Php::getBinary(),
+    'PHP Configuration File' => Php::getIniPath(),
+    'Max Execution Time' => Php::getMaxExecutionTime() . ' seconds',
+    'Memory Limit' => $this->Number->toReadableSize(Php::getMemoryLimit()),
+    'Upload Max Filesize' => $this->Number->toReadableSize(Php::getUploadMaxFilesize()),
+    'Post Max Size' => $this->Number->toReadableSize(Php::getPostMaxSize()),
 ];
 
-//
 // PHP extensions
-//
-$extensions = get_loaded_extensions();
-asort($extensions);
+$extensions = Php::getLoadedExtensions();
 ?>
 <div class="row">
     <div class="col-md-3">
@@ -31,7 +30,7 @@ asort($extensions);
                     <span class="info-box-icon bg-blue"><i class="fa fa-heart"></i></span>
                     <div class="info-box-content">
                         <span class="info-box-text">PHP version</span>
-                        <span class="info-box-number"><?php echo PHP_VERSION; ?></span>
+                        <span class="info-box-number"><?= Php::getVersion() ?></span>
                     </div>
                 </div>
                 <div class="info-box">
@@ -66,12 +65,13 @@ asort($extensions);
                 <h3 class="box-title">Loaded Extensions</h3>
             </div>
             <div class="box-body">
-
-                <ul class="list-inline">
-                <?php foreach ($extensions as $extension) : ?>
-                    <li><?= $extension ?></li>
-                <?php endforeach; ?>
-                </ul>
+                <dl class="dl-horizontal">
+                <?php
+                    foreach ($extensions as $name => $version) {
+                        print '<dt>' . $name . ':</dt><dd>' . $version . '</dd>';
+                    }
+                ?>
+                </dl>
             </div>
         </div>
     </div>

--- a/src/Template/Element/System/project.ctp
+++ b/src/Template/Element/System/project.ctp
@@ -42,4 +42,7 @@ $projectUrl = Project::getUrl();
             </div>
         </div>
     </div>
+    <div class="col-md-5">
+        <?= $this->element('System/about'); ?>
+    </div>
 </div>

--- a/src/Template/Element/System/project.ctp
+++ b/src/Template/Element/System/project.ctp
@@ -3,28 +3,43 @@
 // Project information
 //
 
-$versions = $this->SystemInfo->getProjectVersions();
+use App\SystemInfo\Project;
+
+$projectName = Project::getName();
+$projectVersion = Project::getDisplayVersion();
+$projectUrl = Project::getUrl();
+
 ?>
 <div class="row">
     <div class="col-md-3">
-        <div class="info-box">
-            <span class="info-box-icon bg-blue"><i class="fa fa-info-circle"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">Project version</span>
-                <span class="info-box-number"><?= $this->SystemInfo->getProjectVersion(); ?></span>
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Project Information</h3>
+            </div>
+            <div class="box-body">
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-info-circle"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Project name</span>
+                        <span class="info-box-number"><?= $projectName ?></span>
+                    </div>
+                </div>
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-tag"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Project version</span>
+                        <span class="info-box-number"><?= $projectVersion ?></span>
+                    </div>
+                </div>
+
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-link"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Project URL</span>
+                        <span class="info-box-number"><?= $this->Html->link($projectUrl, $projectUrl, ['target' => '_blank']) ?></span>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-    <div class="col-md-9">
-        <dl class="dl-horizontal">
-            <dt>Project name:</dt><dd><?= $this->SystemInfo->getProjectName(); ?></dd>
-            <dt>Project URL:</dt><dd><?= 
-                $this->Html->link($this->SystemInfo->getProjectUrl(), $this->SystemInfo->getProjectUrl(), ['target' => '_blank']); 
-            ?></dd>
-            <dt>Project version:</dt><dd><?= $this->SystemInfo->getProjectVersion() ?></dd>
-            <dt>Current build:</dt><dd><?= $versions['current']; ?></dd>
-            <dt>Deployed build:</dt><dd><?= $versions['deployed']; ?></dd>
-            <dt>Previous build:</dt><dd><?= $versions['previous']; ?></dd>
-        </dl>
     </div>
 </div>

--- a/src/Template/Element/System/server.ctp
+++ b/src/Template/Element/System/server.ctp
@@ -1,24 +1,44 @@
 <?php
+//
+// Server information
+//
 
-$server = $this->SystemInfo->getServerInfo();
+use App\SystemInfo\Server;
+
+$server = Server::getInfo();
+
 ?>
 <div class="row">
     <div class="col-md-3">
-        <div class="info-box">
-            <span class="info-box-icon bg-blue"><i class="fa fa-linux"></i></span>
-            <div class="info-box-content">
-                <span class="info-box-text">Operating System</span>
-                <span class="info-box-number"><?php echo PHP_OS; ?></span>
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Summary</h3>
+            </div>
+            <div class="box-body">
+                <div class="info-box">
+                    <span class="info-box-icon bg-blue"><i class="fa fa-linux"></i></span>
+                    <div class="info-box-content">
+                        <span class="info-box-text">Operating System</span>
+                        <span class="info-box-number"><?php echo PHP_OS; ?></span>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
-    <div class="col-md-9">
-        <dl class="dl-horizontal">
-        <?php
-            foreach ($server as $name => $value) {
-                print '<dt>' . $name . ':</dt><dd>' . $value . '</dd>';
-            }
-        ?>
-        </dl>
+    <div class="col-md-3">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Hardware</h3>
+            </div>
+            <div class="box-body">
+                <dl class="dl-horizontal">
+                <?php
+                    foreach ($server as $name => $value) {
+                        print '<dt>' . $name . ':</dt><dd>' . $value . '</dd>';
+                    }
+                ?>
+                </dl>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/View/Helper/SystemInfoHelper.php
+++ b/src/View/Helper/SystemInfoHelper.php
@@ -1,11 +1,13 @@
 <?php
-
 namespace App\View\Helper;
 
-use Cake\Core\Configure;
-use Cake\Core\Plugin;
-use Cake\Datasource\ConnectionManager;
-use Cake\ORM\TableRegistry;
+use App\SystemInfo\Cake;
+use App\SystemInfo\Composer;
+use App\SystemInfo\Database;
+use App\SystemInfo\Git;
+use App\SystemInfo\Project;
+use App\SystemInfo\Server;
+
 use Cake\View\Helper;
 
 /**
@@ -14,29 +16,13 @@ use Cake\View\Helper;
 class SystemInfoHelper extends Helper
 {
     /**
-     * @var $logoSizes
-     */
-    protected $logoSizes = ['mini', 'large'];
-
-    /**
-     * @var $defaultLogoSize
-     */
-    protected $defaultLogoSize = 'mini';
-
-    /**
      *  getProjectVersion method
      *
      * @return string project version
      */
     public function getProjectVersion()
     {
-        // Use PROJECT_VERSION environment variable or fallback
-        $projectVersion = getenv('PROJECT_VERSION') ?: getenv('GIT_BRANCH');
-        $lastCommit = shell_exec('git rev-parse --short HEAD');
-        $lastCommit = $lastCommit ?: 'N/A';
-        $projectVersion = $projectVersion ?: $lastCommit;
-
-        return $projectVersion;
+        return Project::getDisplayVersion();
     }
 
     /**
@@ -46,21 +32,7 @@ class SystemInfoHelper extends Helper
      */
     public function getProjectVersions()
     {
-        // Read build/version* files or use N/A as fallback
-        $versions = [
-            'current' => ROOT . DS . 'build' . DS . 'version',
-            'deployed' => ROOT . DS . 'build' . DS . 'version.ok',
-            'previous' => ROOT . DS . 'build' . DS . 'version.bak',
-        ];
-        foreach ($versions as $version => $file) {
-            if (is_readable($file)) {
-                $versions[$version] = file_get_contents($file);
-            } else {
-                $versions[$version] = 'N/A';
-            }
-        }
-
-        return $versions;
+        return Project::getBuildVersions();
     }
 
     /**
@@ -70,12 +42,7 @@ class SystemInfoHelper extends Helper
      */
     public function getProjectUrl()
     {
-        // Use PROJECT_URL environment variable or fallback URL
-        $projectUrl = getenv('PROJECT_URL');
-        $projectUrl = $projectUrl ?: \Cake\Routing\Router::fullBaseUrl();
-        $projectUrl = $projectUrl ?: 'https://github.com/QoboLtd/project-template-cakephp';
-
-        return $projectUrl;
+        return Project::getUrl();
     }
 
     /**
@@ -85,10 +52,7 @@ class SystemInfoHelper extends Helper
      */
     public function getProjectName()
     {
-        // Use PROJECT_NAME environment variable or project folder name
-        $projectName = getenv('PROJECT_NAME') ?: basename(ROOT);
-
-        return $projectName;
+        return Project::getName();
     }
 
     /**
@@ -98,34 +62,7 @@ class SystemInfoHelper extends Helper
      */
     public function getTableStats()
     {
-        //
-        // Statistics
-        //
-        $allTables = $this->getAllTables();
-        $skipTables = 0;
-        $tableStats = [];
-        foreach ($allTables as $table) {
-            // Skip phinx database schema version tables
-            if (preg_match('/phinxlog/', $table)) {
-                $skipTables++;
-                continue;
-            }
-            // Bypassing any CakePHP logic for permissions, pagination, and so on,
-            // and executing raw query to get reliable data.
-            $sth = ConnectionManager::get('default')->execute("SELECT COUNT(*) AS total FROM `$table`");
-            $result = $sth->fetch('assoc');
-            $tableStats[$table]['total'] = $result['total'];
-
-            $tableInstance = TableRegistry::get($table);
-            $tableStats[$table]['deleted'] = 0;
-            if ($tableInstance->hasField('trashed')) {
-                $sth = ConnectionManager::get('default')->execute("SELECT COUNT(*) AS deleted FROM `$table` WHERE `trashed` IS NOT NULL AND `trashed` <> '0000-00-00 00:00:00'");
-                $result = $sth->fetch('assoc');
-                $tableStats[$table]['deleted'] = $result['deleted'];
-            }
-        }
-
-        return [$skipTables, $tableStats];
+        return Database::getTableStats();
     }
 
     /**
@@ -135,9 +72,7 @@ class SystemInfoHelper extends Helper
      */
     public function getAllTables()
     {
-        $allTables = ConnectionManager::get('default')->schemaCollection()->listTables();
-
-        return $allTables;
+        return Database::getAllTables();
     }
 
     /**
@@ -167,12 +102,7 @@ class SystemInfoHelper extends Helper
      */
     public function getLocalModifications()
     {
-        $localModificationsCommand = $this->getLocalModificationsCommand();
-
-        $localModifications = trim(shell_exec($localModificationsCommand));
-        $localModifications = empty($localModifications) ? [] : explode("\n", $localModifications);
-
-        return $localModifications;
+        return Git::getLocalChanges();
     }
 
     /**
@@ -182,9 +112,7 @@ class SystemInfoHelper extends Helper
      */
     public function getLocalModificationsCommand()
     {
-        $localModificationsCommand = 'git status --porcelain';
-
-        return $localModificationsCommand;
+        return Git::getCommand('localChanges');
     }
 
     /**
@@ -194,18 +122,7 @@ class SystemInfoHelper extends Helper
      */
     public function getServerInfo()
     {
-        $server = [
-            'Hostname' => gethostname(),
-            'Operating System' => implode(' ', [
-                php_uname('s'),
-                php_uname('r'),
-            ]),
-            'Machine Type' => php_uname('m'),
-            'Number of CPUs' => $this->getNumberOfCpus(),
-            'Total RAM' => $this->getTotalRam(),
-        ];
-
-        return $server;
+        return Server::getInfo();
     }
 
     /**
@@ -215,15 +132,7 @@ class SystemInfoHelper extends Helper
      */
     public function getNumberOfCpus()
     {
-        $numCpus = 0;
-        $cpuInfoFile = '/proc/cpuinfo';
-        if (is_file($cpuInfoFile) && is_readable($cpuInfoFile)) {
-            $cpuInfoFile = file($cpuInfoFile);
-            $cpus = preg_grep("/^processor/", $cpuInfoFile);
-            $numCpus = count($cpus);
-        }
-
-        return $numCpus;
+        return Server::getNumberOfCpus();
     }
 
     /**
@@ -233,16 +142,7 @@ class SystemInfoHelper extends Helper
      */
     public function getTotalRam()
     {
-        $totalRam = 'N/A';
-        $memoryInfoFile = '/proc/meminfo';
-        if (is_file($memoryInfoFile) && is_readable($memoryInfoFile)) {
-            $memoryInfoFile = file($memoryInfoFile);
-            $totalMemory = preg_grep("/^MemTotal:/", $memoryInfoFile);
-            list($key, $size, $unit) = preg_split('/\s+/', $totalMemory[0], 3);
-            $totalRam = number_format($size) . ' ' . $unit;
-        }
-
-        return $totalRam;
+        return Server::getTotalRam();
     }
 
     /**
@@ -252,9 +152,7 @@ class SystemInfoHelper extends Helper
      */
     public function getCakePhpPlugins()
     {
-        $plugins = Plugin::loaded();
-
-        return $plugins;
+        return Cake::getLoadedPlugins();
     }
 
     /**
@@ -264,9 +162,7 @@ class SystemInfoHelper extends Helper
      */
     public function getCakePhpVersion()
     {
-        $version = Configure::version();
-
-        return $version;
+        return Cake::getVersion();
     }
 
     /**
@@ -276,17 +172,7 @@ class SystemInfoHelper extends Helper
      */
     public function getComposerPackages()
     {
-        //
-        // Installed composer libraries (from composer.lock file)
-        //
-        $composerLock = ROOT . DS . 'composer.lock';
-        $composer = null;
-        if (is_readable($composerLock)) {
-            $composer = json_decode(file_get_contents($composerLock), true);
-        }
-        $packages = !empty($composer['packages']) ? $composer['packages'] : [];
-
-        return $packages;
+        return Composer::getInstalledPackages();
     }
 
     /**
@@ -298,24 +184,7 @@ class SystemInfoHelper extends Helper
      */
     public function getComposerMatchCounts(array $packages, array $matchWords)
     {
-        $matchCounts = [];
-        foreach ($packages as $package) {
-            // Concatenate all fields that we'll be matching against
-            $matchString = $package['name'];
-            if (!empty($package['description'])) {
-                $matchString .= $package['description'];
-            }
-            foreach ($matchWords as $word) {
-                if (empty($matchCounts[$word])) {
-                    $matchCounts[$word] = 0;
-                }
-                if (preg_match('/' . $word . '/', $matchString)) {
-                    $matchCounts[$word]++;
-                }
-            }
-        }
-
-        return $matchCounts;
+        return Composer::getMatchCounts($packages, $matchWords);
     }
 
     /**
@@ -326,10 +195,7 @@ class SystemInfoHelper extends Helper
      */
     public function getProjectLogo($logoSize = '')
     {
-        $logoSize = in_array($logoSize, $this->logoSizes) ? $logoSize : $this->defaultLogoSize;
-        $logo = Configure::read('Theme.logo.' . $logoSize);
-
-        return $logo;
+        return Project::getLogo($logoSize);
     }
 
     /**
@@ -339,8 +205,6 @@ class SystemInfoHelper extends Helper
      */
     public function getCopyright()
     {
-        $copyright = 'Copyright &copy; ' . date('Y') . ' ' . $this->getProjectName() . '. All rights reserved.';
-
-        return $copyright;
+        return Project::getCopyright();
     }
 }


### PR DESCRIPTION
Extracted most of the functionality from the `SystemInfoHelper`
into standalone classes in `App\SystemInfo`.  These are now much
easier to test, maintain, and extend.

`SystemInfoHelper` for now behaves as before, until the wrapper
methods will be removed in the next major version.

Additionally, reorganized all System Information tab elements to use the
new classes, as well as group related information into the AdminLTE
boxes.  These are easier to maintain, update, and merge.