### PR TITLE
Random salt (task #5518)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,6 @@ TEMPLATE_SRC=etc/nginx.conf.template
 TEMPLATE_DST=etc/nginx.conf
 
 DEBUG=0
-SALT=some_super_secret_random_string_here_which_is_at_least_32_bytes_long
 
 LETSENCRYPT_EMAIL=
 LETSENCRYPT_WEBROOT=

--- a/config/app.php
+++ b/config/app.php
@@ -1,4 +1,6 @@
 <?php
+use Qobo\Utils\Utility\Salt;
+
 try {
     Dotenv::makeMutable();
     Dotenv::load(dirname(__FILE__) . DIRECTORY_SEPARATOR . '..');
@@ -11,7 +13,6 @@ try {
 
 $https = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') ? true : false;
 $debug = (bool)env('DEBUG');
-$salt = getenv('SALT') ?: 'dc363e686e16eafeab563188e3a5264ee73196accaec05a3541b1ce4148d9992';
 
 $logLevels = ['notice', 'info', 'warning', 'error', 'critical', 'alert', 'emergency'];
 if ($debug) {
@@ -118,7 +119,7 @@ return [
      *   You should treat it as extremely sensitive data.
      */
     'Security' => [
-        'salt' => $salt,
+        'salt' => Salt::getSalt(),
     ],
 
     /**


### PR DESCRIPTION
* Removed SALT from .env.example
* Replaced getting the SALT from the environment with the call
  to the `Qobo\Utils\Utility\Salt::getSalt()`.

NOTE: This change requires a version of cakephp-utils plugin with
      the following PR merged in:
      https://github.com/QoboLtd/cakephp-utils/pull/103

The security salt is now generated on the fly and is stored in the
`tmp/security.salt` file.  If the file does not exist or contains
an invalid salt (too short of a string, for example), the file
will be re-generated with the proper salt string.

For all affected users (invalid tokens, CSRF headers, etc), you'll
need to clear cookies, reload the page, and try again.