### PR TITLE
Upgrade tasks improvements (task #5352)

### DIFF
--- a/src/Shell/Task/Upgrade20180226Task.php
+++ b/src/Shell/Task/Upgrade20180226Task.php
@@ -132,7 +132,8 @@ class Upgrade20180226Task extends Shell
 
         $this->info(sprintf('Many-to-many module %s created successfully', $moduleName));
 
-        // bake CSV migration
+        // bake CSV migration (sleeping for 1 second to avoid conflicts)
+        sleep(1);
         $this->CsvMigration->main($moduleName);
     }
 

--- a/src/Shell/UpgradeShell.php
+++ b/src/Shell/UpgradeShell.php
@@ -71,6 +71,8 @@ class UpgradeShell extends Shell
             $result[] = str_replace('Task.php', '', $file);
         }
 
+        sort($result);
+
         return $result;
     }
 }


### PR DESCRIPTION
* Sort upgrade tasks alphabetically.
* Use PHP sleep to avoid migration files conflict.