### PR TITLE
Minor fix of the page title

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -24,6 +24,7 @@ use Cake\Event\EventManager;
 use Cake\Network\Exception\ForbiddenException;
 use Cake\Network\Exception\NotFoundException;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
 use Cake\Utility\Security;
 use Exception;
 use Firebase\JWT\JWT;
@@ -169,7 +170,7 @@ class AppController extends Controller
         $this->viewBuilder()->theme('AdminLTE');
         $this->viewBuilder()->layout('adminlte');
 
-        $title = $this->name;
+        $title = Inflector::humanize(Inflector::underscore($this->name));
         try {
             $mc = new ModuleConfig(ConfigType::MODULE(), $this->name);
             $config = $mc->parse();


### PR DESCRIPTION
If the controller action does set the title of its own, we use
the name of the controller as is.  With this change we pass the
controller name through the Inflector's underscore and humanize
methods, which produces a nicer result for contnroller names that
use multiple words, like TradingAccounts (becomes: Trading Accounts).