### PR TITLE
Adding disable_swagger flag (task #5649)

### DIFF
--- a/src/Feature/FeatureInterface.php
+++ b/src/Feature/FeatureInterface.php
@@ -20,6 +20,13 @@ interface FeatureInterface
     public function isActive();
 
     /**
+     * Feature status for whether the Swagger Doc should be generated
+     *
+     * @return bool
+     */
+    public function isSwaggerActive();
+
+    /**
      * Feature disable method.
      *
      * @return void

--- a/src/Feature/Type/BaseFeature.php
+++ b/src/Feature/Type/BaseFeature.php
@@ -34,6 +34,18 @@ class BaseFeature implements FeatureInterface
     /**
      * {@inheritDoc}
      */
+    public function isSwaggerActive()
+    {
+        if (!$this->isActive()) {
+            return false;
+        }
+
+        return !(bool)$this->config->get('disable_swagger');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function enable()
     {
         //


### PR DESCRIPTION
In case we want to hide Swagger documentation on the enabled Module of the template, we can specify `disable_swagger flag` inside `config/features.php`.


Example:

```php
return [
 'Features' => [
    'Module' . DS . 'ScheduledJobs' => ['active' => true, 'disable_swagger' => false],
 ] 
];
```

The module will be still present in the system, but no Swagger documentation will be generated.