### PR TITLE
Fixing feature activity check (task #5694)

### DIFF
--- a/src/Controller/Api/V1/V0/AppController.php
+++ b/src/Controller/Api/V1/V0/AppController.php
@@ -504,7 +504,7 @@ class AppController extends Controller
         $module = basename($path, 'Controller.php');
 
         $feature = FeatureFactory::get('Module' . DS . $module);
-        if (! $feature->isActive()) {
+        if (! $feature->isSwaggerActive()) {
             return '';
         }
 


### PR DESCRIPTION
Adding correct flag check method, so it will properly disable Swagger documentation even if the feature is enabled.