### PR TITLE
Lock CakePHP version to 3.5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         }
     },
     "require": {
+        "cakephp/cakephp": "~3.5.0",
         "cakephp/migrations": "^1.6",
         "cakephp/plugin-installer": "^1.1",
         "dereuromark/cakephp-databaselog": "^2.1",


### PR DESCRIPTION
Lock CakePHP version to 3.5.* until all deprecation errors are fixed.