### PR TITLE
Fix order of logs in index (task #5830)

### DIFF
--- a/src/Controller/LogsController.php
+++ b/src/Controller/LogsController.php
@@ -8,6 +8,21 @@ use DatabaseLog\Controller\Admin\LogsController as BaseController;
 class LogsController extends BaseController
 {
     /**
+     * Setup pagination
+     *
+     * @var array
+     */
+    public $paginate = [
+        'order' => ['DatabaseLogs.id' => 'DESC'],
+        'fields' => [
+            'DatabaseLogs.created',
+            'DatabaseLogs.type',
+            'DatabaseLogs.message',
+            'DatabaseLogs.id'
+        ]
+    ];
+
+    /**
      * Initialization hook method.
      *
      * Implement this method to avoid having to overwrite


### PR DESCRIPTION
Switch to `ID` field for ordering the log entries in index, as it
is auto-incremented.  `created` field has a precision of 1 second,
therefor sometimes causes issues with ordering where multiple log
entries were created within the same second.