### PR TITLE
Adding missing bits for dynamic tabs (task #5963)

### DIFF
--- a/src/Template/Plugin/CsvMigrations/Element/Associated/tabs-content.ctp
+++ b/src/Template/Plugin/CsvMigrations/Element/Associated/tabs-content.ctp
@@ -31,3 +31,20 @@ $accessFactory = new AccessFactory();
         <?php $active = ''; ?>
     <?php endforeach; ?>
 </div> <!-- .tab-content -->
+<?php
+echo $this->Html->scriptBlock("
+$('#relatedTabs li').each(function(key, element) {
+    var activeTab = localStorage.getItem('activeTab_relatedTabs');
+    var link = $(this).find('a');
+    if (activeTab !== undefined) {
+        if (activeTab == key) {
+            $(link).click();
+        }
+    } else {
+        if ($(this).hasClass('active')) {
+            $(link).click();
+        }
+    }
+});
+", ['block' => 'scriptBottom']);
+?>

--- a/src/Template/Plugin/CsvMigrations/Element/Associated/tabs-list.ctp
+++ b/src/Template/Plugin/CsvMigrations/Element/Associated/tabs-list.ctp
@@ -37,7 +37,7 @@ $setLabels = [];
         ?>
         <li role="presentation" class="<?= $active ?>">
             <?= $this->Html->link($label, '#' . $containerId, [
-                'role' => 'tab', 'data-toggle' => 'tab', 'escape' => false
+                'role' => 'tab', 'data-toggle' => 'tab', 'escape' => false, 'class' => $containerId
             ]);?>
         </li>
         <?php $active = ''; ?>


### PR DESCRIPTION
Few lines of associated tabs JS logic was missing from
recent `cakephp-csv-migrations` change on how we initiate
DataTables within related tabs.