### PR TITLE
Faster logo

### DIFF
--- a/config/admin_lte.php
+++ b/config/admin_lte.php
@@ -3,25 +3,9 @@
  * AdminLTE plugin configuration
  */
 
-// get logo path
-$path = WWW_ROOT . 'img' . DS . 'logo.png';
-// convert to base64 image
-$data = file_get_contents($path);
-$base64 = 'data:image/png;base64,' . base64_encode($data);
-// create logo html img
-$logo = '<img src="' . $base64 . '" alt="Site Logo" />';
-
-// get mini logo path
-$path = WWW_ROOT . 'img' . DS . 'logo-mini.png';
-if (file_exists($path)) {
-    // convert to base64 image
-    $data = file_get_contents($path);
-    $base64 = 'data:image/png;base64,' . base64_encode($data);
-    // create mini logo html img
-    $logoMini = '<img src="' . $base64 . '" alt="Site Logo" />';
-} else {
-    $logoMini = $logo;
-}
+// create logo HTML img tags
+$logo = '<img src="/img/logo.png" alt="Site Logo" />';
+$logoMini = '<img src="/img/logo-mini.png" alt="Site Logo" />';
 
 return [
     'Theme' => [

--- a/src/SystemInfo/Project.php
+++ b/src/SystemInfo/Project.php
@@ -143,7 +143,7 @@ class Project
      *  Get project logo
      *
      * @param string $logoSize of logo - mini or large
-     * @return string base64 encoded project logo
+     * @return string HTML img tag with project logo
      */
     public static function getLogo($logoSize = '')
     {

--- a/src/View/Helper/SystemInfoHelper.php
+++ b/src/View/Helper/SystemInfoHelper.php
@@ -64,7 +64,7 @@ class SystemInfoHelper extends Helper
      *  getProjectLogo method
      *
      * @param string $logoSize of logo - mini or large
-     * @return string base64 encoded project logo
+     * @return string HTML img tag with project logo
      */
     public function getProjectLogo($logoSize = '')
     {


### PR DESCRIPTION
Historically, we were base64-encoding the logo image so that it would
be easier to use in outgoing HTML emails.  Email functionality has
been changed a while back, so base64-encoding is not necessary anymore.

Without it, the page loads should be slightly faster:

* Separate HTTP request for the logo image
* Smaller page size (no inlining of the logo)
* Browser caching (separate image, no inlining)
* No unnecessary fetching of logo file content and base64 encoding