### PR TITLE
Unlink functionality for associated records (task #6327)

### DIFF
--- a/src/Event/Controller/Api/BaseActionListener.php
+++ b/src/Event/Controller/Api/BaseActionListener.php
@@ -334,4 +334,32 @@ abstract class BaseActionListener implements EventListenerInterface
             ]));
         }
     }
+
+    /**
+     * Method that retrieves and attaches menu elements to API response.
+     *
+     * @param \Cake\Datasource\ResultSetInterface $resultSet ResultSet object
+     * @param \Cake\Datasource\RepositoryInterface $table Table instance
+     * @param array $user User info
+     * @param array $data for extra fields like origin Id
+     * @return void
+     */
+    protected function attachRelatedMenu(ResultSetInterface $resultSet, RepositoryInterface $table, array $user, array $data)
+    {
+        $view = new View();
+        $controllerName = App::shortName(get_class($table), 'Model/Table', 'Table');
+
+        foreach ($resultSet as $entity) {
+            $entity->set(static::MENU_PROPERTY_NAME, $view->element('Module/Menu/related_actions', [
+                'plugin' => false,
+                'controller' => $controllerName,
+                'displayField' => $table->getDisplayField(),
+                'entity' => $entity,
+                'user' => $user,
+                'associationController' => $data['associationController'],
+                'associationName' => $data['associationName'],
+                'associationId' => $data['associationId'],
+            ]));
+        }
+    }
 }

--- a/src/Event/Controller/Api/RelatedActionListener.php
+++ b/src/Event/Controller/Api/RelatedActionListener.php
@@ -75,7 +75,11 @@ class RelatedActionListener extends BaseActionListener
         }
 
         if ((bool)$event->getSubject()->request->getQuery(static::FLAG_INCLUDE_MENUS)) {
-            $this->attachMenu($resultSet, $table, $event->getSubject()->Auth->user());
+            $this->attachRelatedMenu($resultSet, $table, $event->getSubject()->Auth->user(), [
+                'associationController' => $event->getSubject()->request->getParam('controller'),
+                'associationName' => $table->getRegistryAlias(),
+                'associationId' => $event->getSubject()->request->getParam('pass.0'),
+            ]);
         }
     }
 

--- a/src/Template/Element/Module/Menu/related_actions.ctp
+++ b/src/Template/Element/Module/Menu/related_actions.ctp
@@ -1,0 +1,56 @@
+<?php
+$menu = [];
+
+$url = ['prefix' => false, 'plugin' => $plugin, 'controller' => $controller, 'action' => 'view', $entity->id];
+$menu[] = ['url' => $url, 'icon' => 'eye', 'label' => __('View'), 'type' => 'link_button', 'order' => 10];
+
+$url = ['prefix' => false, 'plugin' => $plugin, 'controller' => $controller, 'action' => 'edit', $entity->id];
+$menu[] = ['url' => $url, 'icon' => 'pencil', 'label' => __('Edit'), 'type' => 'link_button', 'order' => 20];
+
+$url = [
+    'prefix' => 'api',
+    'plugin' => $plugin,
+    'controller' => $controller,
+    'action' => 'delete',
+    '_ext' => 'json',
+    $entity->id
+];
+$menu[] = [
+    'url' => $url,
+    'icon' => 'trash',
+    'label' => __('Delete'),
+    'dataType' => 'ajax-delete-record',
+    'type' => 'link_button',
+    'confirmMsg' => __(
+        'Are you sure you want to delete {0}?',
+        $entity->has($displayField) && !empty($entity->{$displayField}) ?
+                strip_tags($entity->{$displayField}) :
+                'this record'
+    ),
+    'order' => 30
+];
+
+$url = [
+    'prefix' => false,
+    'plugin' => $plugin,
+    'controller' => $associationController,
+    'action' => 'unlink',
+    $associationId,
+    $associationName,
+    $entity->id,
+];
+
+$menu[] = [
+    'url' => $url,
+    'icon' => 'chain-broken',
+    'label' => __('Unlink'),
+    'dataType' => 'ajax-delete-record',
+    'type' => 'postlink_button',
+    'confirmMsg' => __(
+        'Are you sure you want to unlink {0}?',
+        strip_tags($entity->{$displayField})
+    ),
+    'order' => 40
+];
+
+echo $this->element('menu-render', ['menu' => $menu, 'user' => $user, 'menuType' => 'actions']);


### PR DESCRIPTION
In previous releases of `cakephp-csv-migrations` we got rid off `associated_records.ctp` view file, that had `$association` checks on what template element to use while rendering tabbed records.

Reference: https://github.com/QoboLtd/cakephp-csv-migrations/commit/56837419c8fc20789172bbd10893d14ec7296f1b

After restructuring associated records into AJAX and later, changing it into dynamic loading we switched to `index_actions` as default rendering template, forgetting about `unlink` functionality.

