### PR TITLE
Adding csv-migrations patch to overwritten element (task #6323)

### DIFF
--- a/src/Template/Plugin/CsvMigrations/Element/Associated/tabs-content.ctp
+++ b/src/Template/Plugin/CsvMigrations/Element/Associated/tabs-content.ctp
@@ -33,18 +33,25 @@ $accessFactory = new AccessFactory();
 </div> <!-- .tab-content -->
 <?php
 echo $this->Html->scriptBlock("
-$('#relatedTabs li').each(function(key, element) {
-    var activeTab = localStorage.getItem('activeTab_relatedTabs');
-    var link = $(this).find('a');
-    if (activeTab !== undefined) {
+var tabClicked = false;
+var activeTab = localStorage.getItem('activeTab_relatedTabs');
+
+if (activeTab) {
+    $('#relatedTabs li').each(function(key, element) {
+        var link = $(this).find('a');
         if (activeTab == key) {
+            tabClicked = true;
             $(link).click();
         }
+    });
+}
+if (!tabClicked) {
+    var activeTab = $('#relatedTabs li.active');
+    if (activeTab) {
+        $(activeTab).find('a').click();
     } else {
-        if ($(this).hasClass('active')) {
-            $(link).click();
-        }
+        $('#relatedTabs li').first().find('a').click();
     }
-});
+}
 ", ['block' => 'scriptBottom']);
 ?>


### PR DESCRIPTION
Patch deriving from `cakephp-csv-migrations` plugin that should fix autoloading of active tabs for related records once you're viewing specific record. Reference: https://github.com/QoboLtd/cakephp-csv-migrations/commit/35a5bb1d84404845bcb2c724e3bdc3b5f8e2559d