### PR TITLE
Scheduled Jobs: saving error logs only (Task #6652)

### DIFF
--- a/config/Migrations/20180720122957_AlterScheduledJobs.php
+++ b/config/Migrations/20180720122957_AlterScheduledJobs.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AlterScheduledJobs extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('scheduled_jobs');
+        $table->addColumn('last_run_date', 'datetime', [
+            'default' => null,
+            'null' => true,
+        ]);
+        $table->update();
+    }
+}

--- a/config/Modules/ScheduledJobs/config/fields.json
+++ b/config/Modules/ScheduledJobs/config/fields.json
@@ -13,5 +13,8 @@
     },
     "end_date": {
         "renderAs": "datetime"
+    },
+    "last_run_date": {
+        "renderAs": "datetime"
     }
 }

--- a/config/Modules/ScheduledJobs/views/index.json
+++ b/config/Modules/ScheduledJobs/views/index.json
@@ -14,6 +14,9 @@
         ],
         [
             "end_date"
+        ],
+        [
+            "last_run_date"
         ]
     ]
 }

--- a/config/Modules/ScheduledJobs/views/view.json
+++ b/config/Modules/ScheduledJobs/views/view.json
@@ -12,7 +12,8 @@
         ],
         [
             "Recurrence",
-            "recurrence"
+            "recurrence",
+            "last_run_date"
         ],
         [
             "Recurrence",

--- a/src/Shell/CronShell.php
+++ b/src/Shell/CronShell.php
@@ -89,8 +89,12 @@ class CronShell extends Shell
                 $state = $instance->run($entity->options);
                 $this->info("Finished Scheduled Task [{$entity->name}]");
                 $this->verbose("Scheduled Task [" . $entity->name . "] finished with: " . print_r($state, true));
-                $this->ScheduledJobLogs->logJob($entity, $state, $now);
+                if ($state['state'] > 0) {
+                    $this->ScheduledJobLogs->logJob($entity, $state, $now);
+                }
                 $this->info("Logged Scheduled Task [{$entity->name}]");
+                $entity = $this->ScheduledJobs->patchEntity($entity, ['last_run_date' => Time::now()]);
+                $this->ScheduledJobs->save($entity);
             } catch (Exception $e) {
                 $this->info("Scheduled Task [{$entity->name}] is already in progress. Skipping.");
                 continue;

--- a/src/Template/ScheduledJobs/index.ctp
+++ b/src/Template/ScheduledJobs/index.ctp
@@ -25,7 +25,7 @@ $dtOptions = [
             'controller' => $this->name,
             'action' => $this->request->param('action')
         ]) . '.json',
-        'columns' => ['name', 'active', 'job', 'recurrence', 'start_date', 'end_date', '_Menus'],
+        'columns' => ['name', 'active', 'job', 'recurrence', 'start_date', 'end_date', 'last_run_date', '_Menus'],
         'extras' => ['format' => 'pretty', 'menus' => 1]
     ],
 ];
@@ -66,6 +66,7 @@ echo $this->Html->scriptBlock(
                         <th><?= __('Recurrence'); ?></th>
                         <th><?= __('Start');?></th>
                         <th><?= __('End');?></th>
+                        <th><?= __('Last Run Date');?></th>
                         <th><?= __('Actions');?></th>
                     </tr>
                 </thead>


### PR DESCRIPTION
To prevent too much logging, we only store error logs.
To know when the script ran last time, we store `last_run_date` on the scheduled job record.