### PR TITLE
Allow passing NULL to reset BLOB fields (task #6433)

### DIFF
--- a/src/Database/Type/EncodedFileType.php
+++ b/src/Database/Type/EncodedFileType.php
@@ -35,6 +35,10 @@ class EncodedFileType extends Type
      */
     public function toDatabase($value, Driver $driver)
     {
+        if (is_null($value)) {
+            return null;
+        }
+
         if (! is_array($value)) {
             throw new InvalidArgumentException('Encoded file value must be an array');
         }


### PR DESCRIPTION
With custom EncodedFileType field we couldn't reset the BLOB values, though most of those fields were allowed to be set NULL.

Example:

```php

$query = $this->Users->find()->all();

foreach ($query as $entity) {
   $entity = $this->Users->patchEntity($entity, ['image' => null]);
   $this->Users->save($entity);
}

```
In this case,  `toDatabase()` will throw an exception `Encoded file value must be an array`.