### PR TITLE
Upgraded Qobo cakephp-menu plugin to v13.* (task #809)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "pyrech/composer-changelogs": "~1.4",
         "qobo/cakephp-csv-migrations": "^31.0",
         "qobo/cakephp-groups": "^9.0",
-        "qobo/cakephp-menu": "^12.0",
+        "qobo/cakephp-menu": "^13.0",
         "qobo/cakephp-roles-capabilities": "^16.0",
         "qobo/cakephp-search": "^18.0",
         "qobo/cakephp-utils": "^7.4",


### PR DESCRIPTION
For more details see release [v13.0.0](https://github.com/QoboLtd/cakephp-menu/releases/tag/v13.0.0)