### PR TITLE
Disable delete action when user is locked (task #6800)

### DIFF
--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -18,7 +18,7 @@ echo $this->Html->scriptBlock(
     '$(".table-datatable").DataTable({
         stateSave:true,
         paging:true,
-        searching:true
+        searching:false
     });',
     ['block' => 'scriptBottom']
 );

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -94,16 +94,18 @@ echo $this->Html->scriptBlock(
                                     ['action' => 'change-user-password', $user->id],
                                     ['title' => __('Change User Password'), 'class' => 'btn btn-default btn-sm', 'escape' => false]
                                 ) ?>
-                                <?= $this->Form->postLink(
-                                    '<i class="fa fa-trash"></i>',
-                                    ['controller' => 'Users', 'action' => 'delete', $user->id],
-                                    [
-                                        'confirm' => __('Are you sure you want to delete # {0}?', $user->id),
-                                        'title' => __('Delete'),
-                                        'class' => 'btn btn-default btn-sm',
-                                        'escape' => false
-                                    ]
-                                ) ?>
+                                <?php if (!in_array($user->username, $lockedUsers)): ?>
+                                    <?= $this->Form->postLink(
+                                        '<i class="fa fa-trash"></i>',
+                                        ['controller' => 'Users', 'action' => 'delete', $user->id],
+                                        [
+                                            'confirm' => __('Are you sure you want to delete # {0}?', $user->id),
+                                            'title' => __('Delete'),
+                                            'class' => 'btn btn-default btn-sm',
+                                            'escape' => false,
+                                        ]
+                                    ) ?>
+                                <?php endif; ?>
                             </div>
                         </td>
                     </tr>

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -94,7 +94,19 @@ echo $this->Html->scriptBlock(
                                     ['action' => 'change-user-password', $user->id],
                                     ['title' => __('Change User Password'), 'class' => 'btn btn-default btn-sm', 'escape' => false]
                                 ) ?>
-                                <?php if (!in_array($user->username, $lockedUsers)): ?>
+                                <?php if (in_array($user->username, $lockedUsers)): ?>
+                                    <?= $this->Form->postLink(
+                                        '<i class="fa fa-trash"></i>',
+                                        [],
+                                        [
+                                            'title' => __('User can not be deleted'),
+                                            'class' => 'btn btn-default btn-sm',
+                                            'escape' => false,
+                                            'disabled' => true,
+                                            'onClick' => 'return false',
+                                        ]
+                                    ) ?>
+                                <?php else: ?>
                                     <?= $this->Form->postLink(
                                         '<i class="fa fa-trash"></i>',
                                         ['controller' => 'Users', 'action' => 'delete', $user->id],

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -111,7 +111,7 @@ echo $this->Html->scriptBlock(
                                         '<i class="fa fa-trash"></i>',
                                         ['controller' => 'Users', 'action' => 'delete', $user->id],
                                         [
-                                            'confirm' => __('Are you sure you want to delete # {0}?', $user->id),
+                                            'confirm' => __('Are you sure you want to delete user {0}?', $user->username),
                                             'title' => __('Delete'),
                                             'class' => 'btn btn-default btn-sm',
                                             'escape' => false,

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -341,13 +341,9 @@ class UsersControllerTest extends IntegrationTestCase
         $this->enableSecurityToken();
         $this->withSession();
 
-        try {
-            $this->disableErrorHandlerMiddleware();
-            $this->delete('/users/delete/' . $this->userId);
-            $this->fail('Expected ForbiddenException');
-        } catch (ForbiddenException $e) {
-            $this->assertTrue(true);
-        }
+        $this->disableErrorHandlerMiddleware();
+        $this->expectException(ForbiddenException::class);
+        $this->delete('/users/delete/' . $this->userId);
     }
 
     public function testDeleteWithoutSession()

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -350,10 +350,11 @@ class UsersControllerTest extends IntegrationTestCase
         $this->enableCsrfToken();
         $this->enableSecurityToken();
 
-        $this->delete('/users/delete/' . $this->userId);
+        $userId = '00000000-0000-0000-0000-000000000001';
+        $this->delete('/users/delete/' . $userId);
         $this->assertRedirect();
 
-        $query = $this->table->find()->where(['id' => $this->userId]);
+        $query = $this->table->find()->where(['id' => $userId]);
         $this->assertFalse($query->isEmpty());
     }
 }

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -3,6 +3,7 @@ namespace App\Test\TestCase\Controller;
 
 use App\Controller\DblistsController;
 use Cake\Core\Configure;
+use Cake\Network\Exception\ForbiddenException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
 
@@ -340,10 +341,13 @@ class UsersControllerTest extends IntegrationTestCase
         $this->enableSecurityToken();
         $this->withSession();
 
-        $this->disableErrorHandlerMiddleware();
-        $this->delete('/users/delete/' . $this->userId);
-        $this->assertResponseError();
-        $this->assertResponseCode(403);
+        try {
+            $this->disableErrorHandlerMiddleware();
+            $this->delete('/users/delete/' . $this->userId);
+            $this->fail('Expected ForbiddenException');
+        } catch (ForbiddenException $e) {
+            $this->assertTrue(true);
+        }
     }
 
     public function testDeleteWithoutSession()

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -342,6 +342,7 @@ class UsersControllerTest extends IntegrationTestCase
 
         $this->delete('/users/delete/' . $this->userId);
         $this->assertResponseError();
+        $this->assertResponseCode(403);
     }
 
     public function testDeleteWithoutSession()

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -340,6 +340,7 @@ class UsersControllerTest extends IntegrationTestCase
         $this->enableSecurityToken();
         $this->withSession();
 
+        $this->disableErrorHandlerMiddleware();
         $this->delete('/users/delete/' . $this->userId);
         $this->assertResponseError();
         $this->assertResponseCode(403);

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -320,17 +320,28 @@ class UsersControllerTest extends IntegrationTestCase
         $this->assertEquals($entity, $this->table->get($this->userId));
     }
 
-    public function testDelete()
+    public function testDeleteAnyUser()
+    {
+        $this->enableCsrfToken();
+        $this->enableSecurityToken();
+        $this->withSession();
+
+        $userId = '00000000-0000-0000-0000-000000000001';
+        $this->delete('/users/delete/' . $userId);
+        $this->assertRedirect();
+
+        $query = $this->table->find()->where(['id' => $userId]);
+        $this->assertTrue($query->isEmpty());
+    }
+
+    public function testDeleteSameUser()
     {
         $this->enableCsrfToken();
         $this->enableSecurityToken();
         $this->withSession();
 
         $this->delete('/users/delete/' . $this->userId);
-        $this->assertRedirect();
-
-        $query = $this->table->find()->where(['id' => $this->userId]);
-        $this->assertTrue($query->isEmpty());
+        $this->assertResponseError();
     }
 
     public function testDeleteWithoutSession()


### PR DESCRIPTION
A user can be deleted only and only if:

- User is not the system user defined in .env
- User is not the currently logged in user