### PR TITLE
Lookup fixes (task #6717)

### DIFF
--- a/src/Controller/ScheduledJobLogsController.php
+++ b/src/Controller/ScheduledJobLogsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Controller;
 
+use Cake\Validation\Validation;
 use CsvMigrations\Controller\AppController as BaseController;
 
 /**
@@ -33,7 +34,7 @@ class ScheduledJobLogsController extends BaseController
             ->where([$this->{$this->name}->getPrimaryKey() => $id])
             ->first();
 
-        if (empty($entity)) {
+        if (empty($entity) && ! Validation::uuid($id)) {
             $entity = $this->{$this->name}->find()
                 ->applyOptions(['lookup' => true, 'value' => $id])
                 ->firstOrFail();

--- a/src/Controller/ScheduledJobLogsController.php
+++ b/src/Controller/ScheduledJobLogsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Controller;
 
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Validation\Validation;
 use CsvMigrations\Controller\AppController as BaseController;
 
@@ -38,6 +39,13 @@ class ScheduledJobLogsController extends BaseController
             $entity = $this->{$this->name}->find()
                 ->applyOptions(['lookup' => true, 'value' => $id])
                 ->firstOrFail();
+        }
+
+        if (empty($entity)) {
+            throw new RecordNotFoundException(sprintf(
+                'Record not found in table "%s"',
+                $this->{$this->name}->getTable()
+            ));
         }
 
         $this->set('entity', $entity);

--- a/src/Event/Model/LookupListener.php
+++ b/src/Event/Model/LookupListener.php
@@ -54,6 +54,12 @@ class LookupListener implements EventListenerInterface
 
         $config = (new ModuleConfig(ConfigType::MODULE(), $event->getSubject()->getAlias()))->parse();
         if (empty($config->table->lookup_fields)) {
+            // fail-safe binding of primary key to query's where clause, if lookup
+            // fields are not defined, to avoid random record retrieval.
+            $query->where([
+                $event->getSubject()->aliasField($event->getSubject()->getPrimaryKey()) => $options['value']
+            ]);
+
             return;
         }
 


### PR DESCRIPTION
* Added fail-safe binding of the primary key to the query's where clause if the lookup fields are not defined, to avoid random record retrieval.
* Apply lookup logic only if provided value is not a UUID
* Throw record not found exception if failed to fetch scheduled job log record with id or lookup fields