### PR TITLE
Add Whoops as the default exception renderrer (task #6872)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "cakephp/migrations": "^1.6",
         "cakephp/plugin-installer": "^1.1",
         "dereuromark/cakephp-databaselog": "^2.1",
+        "dereuromark/cakephp-whoops": "^0.1.2",
         "lasserafn/php-initial-avatar-generator": "^2.3",
         "mobiledetect/mobiledetectlib": "2.*",
         "pelago/emogrifier": "^1.2",

--- a/config/app.php
+++ b/config/app.php
@@ -452,4 +452,7 @@ return [
     'Swagger' => [
         'crawl' => (bool)getenv('SWAGGER_CRAWL')
     ],
+    'Whoops' => [
+        'editor' => true
+    ]
 ];

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -38,6 +38,7 @@ if (!extension_loaded('intl')) {
     trigger_error('You must enable the intl extension to use CakePHP.', E_USER_ERROR);
 }
 
+use App\Error\HttpErrorHandler;
 use App\Event\Component\UserIdentifyListener;
 use App\Event\Controller\Api\AddActionListener;
 use App\Event\Controller\Api\EditActionListener;
@@ -67,7 +68,6 @@ use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Plugin;
 use Cake\Database\Type;
 use Cake\Datasource\ConnectionManager;
-use Cake\Error\ErrorHandler;
 use Cake\Event\EventManager;
 use Cake\Log\Log;
 use Cake\Network\Email\Email;
@@ -138,7 +138,7 @@ $isCli = php_sapi_name() === 'cli';
 if ($isCli) {
     (new ConsoleErrorHandler(Configure::read('Error')))->register();
 } else {
-    (new ErrorHandler(Configure::read('Error')))->register();
+    (new HttpErrorHandler(Configure::read('Error')))->register();
 }
 
 // Include the CLI bootstrap overrides.

--- a/src/Error/HttpErrorHandler.php
+++ b/src/Error/HttpErrorHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Error;
+
+use CakephpWhoops\Error\WhoopsHandler;
+use Cake\Core\Configure;
+use Cake\Core\Exception\Exception as CakeException;
+use Cake\Routing\Router;
+
+/**
+ * Class HttpErrorHandler
+ * Application HTTP Error Handler
+ * @package App\Error
+ */
+class HttpErrorHandler extends WhoopsHandler
+{
+    /**
+     * Extends default implementation to add data tables related to CakePHP
+     * @param \Exception $exception Caught exception to be handled
+     */
+    protected function _displayException($exception)
+    {
+        if (!Configure::read('debug')) {
+            parent::_displayException($exception);
+
+            return;
+        }
+
+        // Prepare handler with data tables
+        $handler = $this->getHandler();
+
+        if ($exception instanceof CakeException) {
+            $handler->addDataTable('Cake Exception', $exception->getAttributes());
+        }
+
+        $request = Router::getRequest(true);
+        $handler->addDataTable('Cake Request', $request->params);
+
+        $whoops = $this->getWhoopsInstance();
+        $whoops->pushHandler($handler);
+        $whoops->handleException($exception);
+    }
+}


### PR DESCRIPTION
Utilize Whoops as the default web handler for both Expressions and Errors, when DEBUG is enabled.

