### PR TITLE
Making sure that scheduled jobs use zero-seconds (task #6874)

### DIFF
--- a/src/Model/Table/ScheduledJobsTable.php
+++ b/src/Model/Table/ScheduledJobsTable.php
@@ -60,6 +60,8 @@ class ScheduledJobsTable extends AppTable
         if ($entity->isNew()) {
             $entity->set('created_by', $user['id']);
         }
+
+        $entity->start_date = $this->getStartDate($entity->start_date);
     }
 
     /**
@@ -294,5 +296,23 @@ class ScheduledJobsTable extends AppTable
         $rrule = new RRule($config);
 
         return $rrule;
+    }
+
+    /**
+     * Get Start Date right
+     *
+     * Avoid using second in case it might mismatch timeToInvoke() method
+     *
+     * @param mixed $time of the entity
+     *
+     * @return \Cake\I18n\Time with zero-value seconds.
+     */
+    public function getStartDate($time)
+    {
+        if (is_string($time)) {
+            return Time::parse($time)->second(0);
+        }
+
+        return $time->second(0);
     }
 }

--- a/src/Shell/CronShell.php
+++ b/src/Shell/CronShell.php
@@ -65,7 +65,7 @@ class CronShell extends Shell
             return true;
         }
 
-        $now = Time::now();
+        $now = $this->ScheduledJobs->getStartDate(Time::now());
 
         foreach ($jobs as $entity) {
             $shouldRun = false;

--- a/tests/TestCase/Controller/ScheduledJobsControllerTest.php
+++ b/tests/TestCase/Controller/ScheduledJobsControllerTest.php
@@ -3,6 +3,7 @@ namespace App\Test\TestCase\Controller;
 
 use App\Controller\ScheduledJobsController;
 use App\Feature\Factory;
+use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
 
@@ -55,13 +56,27 @@ class ScheduledJobsControllerTest extends IntegrationTestCase
         }
 
         $data = [
-            'name' => 'App::Foo:bar test scheduled job'
+            'name' => 'App::Foo:bar test scheduled job',
+            'start_date' => '2018-09-01 15:31:23',
         ];
 
         $this->post('/scheduled-jobs/add', $data);
 
+        $entity = $this->table->find()->where(['name' => $data['name']])->first();
         $this->assertRedirect(['action' => 'index']);
         $this->assertSession('Scheduled Job has been saved.', 'Flash.flash.0.message');
+        $this->assertEquals($this->table->getStartDate($data['start_date']), $entity->start_date);
+
+        $time = Time::now();
+
+        $data = [
+            'name' => 'App::Foo:bar test scheduled job - 2',
+            'start_date' => $time,
+        ];
+
+        $this->post('/scheduled-jobs/add', $data);
+        $entity = $this->table->find()->where(['name' => $data['name']])->first();
+        $this->assertEquals($this->table->getStartDate($data['start_date']), $entity->start_date);
     }
 
     public function testEdit()
@@ -76,14 +91,18 @@ class ScheduledJobsControllerTest extends IntegrationTestCase
 
         $data = [
             'name' => 'Foo Job',
+            'start_date' => '2018-09-01 15:31:23',
         ];
 
         $this->post('/scheduled-jobs/edit/' . $id, $data);
+
+        $entity = $this->table->find()->where(['name' => $id])->first();
 
         $this->assertRedirect(['action' => 'view', $id]);
         $this->assertSession('The record has been saved.', 'Flash.flash.0.message');
 
         $entity = $this->table->get($id);
         $this->assertEquals($entity->get('name'), $data['name']);
+        $this->assertEquals($this->table->getStartDate($data['start_date']), $entity->start_date);
     }
 }


### PR DESCRIPTION
To avoid time mismatch running Scheduled Jobs we zero-fill seconds, as theoretically cron should execute every minute.