### PR TITLE
Adding Future Dates for Magic Values (task #6886)

### DIFF
--- a/src/Event/Plugin/CsvMigrations/FieldHandlers/MagicDefaultValueListener.php
+++ b/src/Event/Plugin/CsvMigrations/FieldHandlers/MagicDefaultValueListener.php
@@ -112,4 +112,52 @@ class MagicDefaultValueListener implements EventListenerInterface
 
         return $view->viewVars['user']['id'];
     }
+
+    /**
+     * NEXT_WEEK_DATE magic value
+     *
+     * @param object $fieldHandler instance
+     * @return string
+     */
+    protected function getNextWeekDateValue($fieldHandler = null)
+    {
+        return $this->getFutureDateValue($fieldHandler);
+    }
+
+    /**
+     * NEXT_MONTH_DATE magic value
+     *
+     * @param object $fieldHandler instance
+     * @return string
+     */
+    protected function getNextMonthDateValue($fieldHandler = null)
+    {
+        return $this->getFutureDateValue($fieldHandler, 'month');
+    }
+
+    /**
+     * NEXT_YEAR_DATE magic value
+     *
+     * @param object $fieldHandler instance
+     * @return string
+     */
+    protected function getNextYearDateValue($fieldHandler = null)
+    {
+        return $this->getFutureDateValue($fieldHandler, 'year');
+    }
+
+    /**
+     * Get future magic value strings
+     *
+     * @param object $fieldHandler instance
+     * @param string $duration of the next timestamp
+     *
+     * @return string
+     */
+    private function getFutureDateValue($fieldHandler = null, $duration = 'week')
+    {
+        $duration = strtolower($duration);
+
+        return date('Y-m-d', strtotime('+ 1 ' . $duration));
+    }
 }

--- a/src/Event/Plugin/CsvMigrations/FieldHandlers/MagicDefaultValueListener.php
+++ b/src/Event/Plugin/CsvMigrations/FieldHandlers/MagicDefaultValueListener.php
@@ -121,7 +121,7 @@ class MagicDefaultValueListener implements EventListenerInterface
      */
     protected function getNextWeekDateValue($fieldHandler = null)
     {
-        return $this->getFutureDateValue($fieldHandler);
+        return $this->getFutureDateValue();
     }
 
     /**
@@ -132,7 +132,7 @@ class MagicDefaultValueListener implements EventListenerInterface
      */
     protected function getNextMonthDateValue($fieldHandler = null)
     {
-        return $this->getFutureDateValue($fieldHandler, 'month');
+        return $this->getFutureDateValue('month');
     }
 
     /**
@@ -143,18 +143,17 @@ class MagicDefaultValueListener implements EventListenerInterface
      */
     protected function getNextYearDateValue($fieldHandler = null)
     {
-        return $this->getFutureDateValue($fieldHandler, 'year');
+        return $this->getFutureDateValue('year');
     }
 
     /**
      * Get future magic value strings
      *
-     * @param object $fieldHandler instance
      * @param string $duration of the next timestamp
      *
      * @return string
      */
-    private function getFutureDateValue($fieldHandler = null, $duration = 'week')
+    private function getFutureDateValue($duration = 'week')
     {
         $duration = strtolower($duration);
 


### PR DESCRIPTION
- Adding more Magic values for search and `fields.json` default values.

Now you can specify `NEXT_(week|month|year)_DATE` magic values that are super comfy for datepickers and other date-related functionality.