### PR TITLE
Since option for database stats subcommand (task #6954)

### DIFF
--- a/src/Shell/DatabaseLogShell.php
+++ b/src/Shell/DatabaseLogShell.php
@@ -79,6 +79,10 @@ class DatabaseLogShell extends BaseShell
         $statsConfig = Configure::read('DatabaseLog.stats');
         $result = is_array($statsConfig) ? array_merge($defaultConfig, $statsConfig) : $defaultConfig;
 
+        if (isset($this->params['since'])) {
+            $result['period'] = $this->params['since'];
+        }
+
         return $result;
     }
 
@@ -139,6 +143,14 @@ class DatabaseLogShell extends BaseShell
         ]);
         $parser->addSubcommand('stats', [
             'help' => 'Show log stats',
+            'parser' => [
+                'options' => [
+                    'since' => [
+                        'help' => __('Period to be exported i.e. 1 day'),
+                        'required' => false,
+                    ]
+                ]
+            ],
         ]);
 
         return $parser;


### PR DESCRIPTION
Introduces a new option `--since` for the stats subcommand. The following are valid and overwrite the default period.

```
./bin/cake database_log stats --since="-30 days"
./bin/cake database_log stats --since="aug 2018"
./bin/cake database_log stats --since="aug 15 2018"
```