### PR TITLE
Searchable / Sortable virtual fields for API Lookup (task #6708)

### DIFF
--- a/src/Event/Controller/Api/LookupActionListener.php
+++ b/src/Event/Controller/Api/LookupActionListener.php
@@ -212,7 +212,7 @@ class LookupActionListener extends BaseActionListener
      * @param array $fields List of mixed real and virtual fields
      * @return array
      */
-    public function extractVirtualFields(RepositoryInterface $table, array $fields)
+    private function extractVirtualFields(RepositoryInterface $table, array $fields)
     {
         $virtualFields = $this->_getVirtualFields($table);
 


### PR DESCRIPTION
This PR extends the work made as apart of https://github.com/QoboLtd/cakephp-csv-migrations/pull/578 , by extracting the real fields from any specified virtual field to allow sorting and search.