### PR TITLE
Prepend avatars (task #6982)

### DIFF
--- a/config/admin_lte.php
+++ b/config/admin_lte.php
@@ -28,5 +28,6 @@ return [
         'skin' => 'blue',
         'skinUrl' => 'AdminLTE.skins/skin-blue.min',
         'backgroundImages' => 'qobo',
+        'prependAvatars' => true,
     ],
 ];

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -62,7 +62,12 @@ echo $this->Html->scriptBlock(
                 <tbody>
                 <?php foreach ($Users as $user) : ?>
                     <tr>
-                        <td><?= h($user->username) ?></td>
+                        <td>
+                            <?php if (Configure::read('Theme.prependAvatars', true) && isset($user->image_src)): ?>
+                            <img alt="User Image" src="<?= $user->image_src ?>" style="width: 20px; height: 20px;" class="img-circle">
+                            <?php endif; ?>
+                            <?= h($user->username) ?>
+                        </td>
                         <td><?= h($user->email) ?></td>
                         <td><?= h($user->first_name) ?></td>
                         <td><?= h($user->last_name) ?></td>

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -63,8 +63,8 @@ echo $this->Html->scriptBlock(
                 <?php foreach ($Users as $user) : ?>
                     <tr>
                         <td>
-                            <?php if (Configure::read('Theme.prependAvatars', true) && isset($user->image_src)): ?>
-                            <img alt="User Image" src="<?= $user->image_src ?>" style="width: 20px; height: 20px;" class="img-circle">
+                            <?php if (Configure::read('Theme.prependAvatars', true) && !empty($user->image_src)): ?>
+                            <img alt="Thumbnail" src="<?= $user->image_src ?>" style="width: 20px; height: 20px;" class="img-circle">
                             <?php endif; ?>
                             <?= h($user->username) ?>
                         </td>


### PR DESCRIPTION
This PR is an extension to work completed in https://github.com/QoboLtd/cakephp-csv-migrations/pull/587

Introduces a new Theme option to prepend avatars, whenever possible. It also, prepends the avatar in users index page (given that the option is enabled).