### PR TITLE
Fix permissions for Home action (task #3086)

### DIFF
--- a/config/roles_capabilities.php
+++ b/config/roles_capabilities.php
@@ -16,6 +16,7 @@ return [
             'skipActions' => [
                 'App\Controller\SystemController' => [
                     'error',
+                    'home',
                 ],
                 'App\Controller\UsersController' => [
                     'changePassword',

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -120,6 +120,7 @@ class AppController extends Controller
                 throw new ForbiddenException();
             }
         } catch (ForbiddenException $e) {
+            $event->stopPropagation();
             if (empty($this->Auth->user())) {
                 $this->Auth->config('authError', false);
 

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -122,7 +122,8 @@ class AppController extends Controller
         } catch (ForbiddenException $e) {
             if (empty($this->Auth->user())) {
                 $this->Auth->config('authError', false);
-                $this->redirect('/login');
+
+                return $this->redirect('/login');
             } else {
                 // send empty response for embedded forms
                 if ($this->request->query('embedded')) {

--- a/src/Controller/SystemController.php
+++ b/src/Controller/SystemController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 use App\Feature\Factory;
 use Cake\Core\Configure;
 use Cake\Event\Event;
+use Cake\Network\Exception\ForbiddenException;
 use Cake\ORM\TableRegistry;
 use Menu\Event\EventName;
 use Menu\MenuBuilder\MenuItemContainerInterface;
@@ -110,5 +111,22 @@ class SystemController extends AppController
         }
 
         return null;
+    }
+
+    /**
+     * Overwrites default access checking to provide access to homepage.
+     * User have access to home action only and only if is already logged in.
+     *
+     * @param array $url Url to be checked
+     * @param array $user Current user, if any
+     * @return bool
+     */
+    protected function _checkAccess($url, $user)
+    {
+        if (empty($user) && $url['action'] === 'home') {
+            return false;
+        }
+
+        return parent::_checkAccess($url, $user);
     }
 }

--- a/src/Controller/SystemController.php
+++ b/src/Controller/SystemController.php
@@ -101,6 +101,10 @@ class SystemController extends AppController
     public function getFirstMenuItem(MenuItemContainerInterface $container)
     {
         foreach ($container->getMenuItems() as $menuItem) {
+            if (!$menuItem->isEnabled()) {
+                continue;
+            }
+
             if (!empty($menuItem->getMenuItems())) {
                 return $this->getFirstMenuItem($menuItem);
             }


### PR DESCRIPTION
This PR improves the work already completed by #619 by adding the following:

* System::home permission check is skipped by default.
* Extend System Controller to apply a custom check and allow access to home action only to authenticated users.
* Skip disable menu items

