### PR TITLE
Backtrace for views (task #7059)

### DIFF
--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -56,9 +56,9 @@ class AppView extends View
      */
     protected function _render($viewFile, $data = [])
     {
-        array_push($this->backtrace, $viewFile);
+        array_unshift($this->backtrace, $viewFile);
         $output = parent::_render($viewFile, $data);
-        array_pop($this->backtrace);
+        array_shift($this->backtrace);
 
         return $output;
     }

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -21,6 +21,11 @@ use Cake\View\View;
 class AppView extends View
 {
     /**
+     * @var array Holds all the views that are currently being rendered
+     */
+    private $backtrace = [];
+
+    /**
      * Initialization hook method.
      *
      * For e.g. use this method to load a helper for all views:
@@ -36,5 +41,35 @@ class AppView extends View
         $this->loadHelper('HtmlEmail');
         $this->loadHelper('SystemInfo');
         $this->loadHelper('CakeDC/Users.User');
+    }
+
+    /**
+     * Extends render method to log backtrace information
+     *
+     * @param string $viewFile Filename of the view
+     * @param array $data Data to include in rendered view. If empty the current
+     *   View::$viewVars will be used.
+     * @return string Rendered output
+     * @throws \LogicException When a block is left open.
+     * @triggers View.beforeRenderFile $this, [$viewFile]
+     * @triggers View.afterRenderFile $this, [$viewFile, $content]
+     */
+    protected function _render($viewFile, $data = [])
+    {
+        array_push($this->trace, $viewFile);
+        $output = parent::_render($viewFile, $data);
+        array_pop($this->trace);
+
+        return $output;
+    }
+
+    /**
+     * Returns the backtrace for this view.
+     *
+     * @return array The backtrace
+     */
+    public function getBacktrace()
+    {
+        return $this->backtrace;
     }
 }

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -56,9 +56,9 @@ class AppView extends View
      */
     protected function _render($viewFile, $data = [])
     {
-        array_push($this->trace, $viewFile);
+        array_push($this->backtrace, $viewFile);
         $output = parent::_render($viewFile, $data);
-        array_pop($this->trace);
+        array_pop($this->backtrace);
 
         return $output;
     }


### PR DESCRIPTION
Extends render method to capture and maintain the backtrack for the current view file. By using the following in your views you can check why a particular element was being included:

``` php
dd($this->getBacktrace());
```