### PR TITLE
'Create dashboard' after dynamic login redirect (task #7039)

### DIFF
--- a/src/Event/Plugin/Menu/View/DashboardMenuListener.php
+++ b/src/Event/Plugin/Menu/View/DashboardMenuListener.php
@@ -81,15 +81,16 @@ class DashboardMenuListener implements EventListenerInterface
         ]);
         $menu->addMenuItem($link);
 
+        $this->addDashboardItemsFromTable($link, $user, 10);
+
+        $createUrl = empty($link->getMenuItems()) ? '/search/dashboards/index' : '/search/dashboards/add';
         $createLink = MenuItemFactory::createMenuItem([
             'label' => 'Create',
-            'url' => '/search/dashboards/add',
+            'url' => $createUrl,
             'icon' => 'plus',
-            'order' => 999999999
+            'order' => PHP_INT_MAX,
         ]);
         $link->addMenuItem($createLink);
-
-        $this->addDashboardItemsFromTable($link, $user, 10);
     }
 
     /**

--- a/src/Template/Plugin/Search/Dashboards/index.ctp
+++ b/src/Template/Plugin/Search/Dashboards/index.ctp
@@ -18,13 +18,19 @@ use RolesCapabilities\Access\AccessFactory;
         <div class="col-xs-12">
             <div class="jumbotron">
                 <h1><?= __('Dashboards') ?></h1>
-                <p><?= __('There are no configured Dashboards for you. Please contact the system administrator.') ?></p>
+                <p>
+                    <?= __('There are no configured Dashboards for you.'); ?>
                 <?php
                     $factory = new AccessFactory();
                     $url = [ 'controller' => $this->request->controller, 'action' => 'add'];
-                    if ($factory->hasAccess($url, $user)):
+                    if (!$factory->hasAccess($url, $user)):
                 ?>
-                <p><?= $this->Html->link(__('{0} Create Dashboard', '<i class="fa fa-plus"></i>'), $url, ['class' => 'btn btn-primary', 'escape' => false]) ?><p>
+                    <?= __('Please contact the system administrator.'); ?>
+                </p>
+                <?php else: ?>
+                <p>
+                <?= $this->Html->link(__('{0} Create Dashboard', '<i class="fa fa-plus"></i>'), $url, ['class' => 'btn btn-primary', 'escape' => false]) ?>
+                <p>
                 <?php endif; ?>
             </div>
         </div>

--- a/src/Template/Plugin/Search/Dashboards/index.ctp
+++ b/src/Template/Plugin/Search/Dashboards/index.ctp
@@ -13,7 +13,7 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-xs-12">
-            <div class="jumbotron" style="border-radius: 3px; background: #ffffff; border-top: 3px solid #d2d6de; margin-top: 24px; padding: 24px;">
+            <div class="jumbotron">
                 <h1><?= __('Dashboards') ?></h1>
                 <p><?= __('There are no configured Dashboards for you. Please contact the system administrator.') ?></p>
                 <p><?= $this->Html->link(__('{0} Create Dashboard', '<i class="fa fa-plus"></i>'), ['action' => 'add'], ['class' => 'btn btn-primary', 'escape' => false]) ?><p>

--- a/src/Template/Plugin/Search/Dashboards/index.ctp
+++ b/src/Template/Plugin/Search/Dashboards/index.ctp
@@ -9,6 +9,9 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
+use RolesCapabilities\Access\AccessFactory;
+
 ?>
 <div class="container-fluid">
     <div class="row">
@@ -16,7 +19,13 @@
             <div class="jumbotron">
                 <h1><?= __('Dashboards') ?></h1>
                 <p><?= __('There are no configured Dashboards for you. Please contact the system administrator.') ?></p>
-                <p><?= $this->Html->link(__('{0} Create Dashboard', '<i class="fa fa-plus"></i>'), ['action' => 'add'], ['class' => 'btn btn-primary', 'escape' => false]) ?><p>
+                <?php
+                    $factory = new AccessFactory();
+                    $url = [ 'controller' => $this->request->controller, 'action' => 'add'];
+                    if ($factory->hasAccess($url, $user)):
+                ?>
+                <p><?= $this->Html->link(__('{0} Create Dashboard', '<i class="fa fa-plus"></i>'), $url, ['class' => 'btn btn-primary', 'escape' => false]) ?><p>
+                <?php endif; ?>
             </div>
         </div>
     </div>

--- a/src/Template/Plugin/Search/Dashboards/index.ctp
+++ b/src/Template/Plugin/Search/Dashboards/index.ctp
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+?>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="jumbotron" style="border-radius: 3px; background: #ffffff; border-top: 3px solid #d2d6de; margin-top: 24px; padding: 24px;">
+                <h1><?= __('Dashboards') ?></h1>
+                <p><?= __('There are no configured Dashboards for you. Please contact the system administrator.') ?></p>
+                <p><?= $this->Html->link(__('{0} Create Dashboard', '<i class="fa fa-plus"></i>'), ['action' => 'add'], ['class' => 'btn btn-primary', 'escape' => false]) ?><p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/webroot/css/custom.css
+++ b/webroot/css/custom.css
@@ -83,3 +83,12 @@
 .box-primary .col-md-2, .box-primary .col-md-4 {
     min-height: 24px;
 }
+
+/** improve jumbotron which is not included in AdminLTE **/
+.container .jumbotron, .container-fluid .jumbotron {
+    border-radius: 3px;
+    background: #ffffff;
+    border-top: 3px solid #d2d6de;
+    margin-top: 24px;
+    padding-top: 24px;
+}


### PR DESCRIPTION
Improve handling of 'Create dashboard' after dynamic login redirect. In particular it will display the index page only and only if the no dashboards were found. 