### PR TITLE
Fixing menu actions issue with ScheduledJobs (task #809)

### DIFF
--- a/src/Event/Plugin/Menu/View/SearchViewListener.php
+++ b/src/Event/Plugin/Menu/View/SearchViewListener.php
@@ -43,7 +43,7 @@ class SearchViewListener implements EventListenerInterface
      */
     public function getMenuItems(Event $event, $name, array $user, $fullBaseUrl = false, array $modules = [], MenuInterface $menu = null)
     {
-        $listens = [MenuName::SEARCH_VIEW];
+        $listens = [MenuName::SEARCH_VIEW, MenuName::MODULE_INDEX_ROW];
         if (!in_array($name, $listens)) {
             return;
         }

--- a/src/Template/Element/Module/Menu/index_actions.ctp
+++ b/src/Template/Element/Module/Menu/index_actions.ctp
@@ -2,5 +2,6 @@
     'name' => \App\Menu\MenuName::MODULE_INDEX_ROW,
     'user' => $user,
     'fullBaseUrl' => false,
-    'renderer' => \Menu\MenuBuilder\MenuActionsRender::class
+    'renderer' => \Menu\MenuBuilder\MenuActionsRender::class,
+    'context' => $entity
 ]) ?>


### PR DESCRIPTION
By passing `context` as ORM Entity we won't stumble upon `$event->getSubject()` returning a Cell object. 