### PR TITLE
Menu defaults (task #5348)

### DIFF
--- a/config/Modules/ScheduledJobs/config/menus.dist.json
+++ b/config/Modules/ScheduledJobs/config/menus.dist.json
@@ -11,7 +11,6 @@
                     "label": "Scheduled Jobs",
                     "desc": "Automated Scripts execution",
                     "url": "/scheduled-jobs/",
-                    "icon": "clock-o",
                     "order": 100
                 }
             ]

--- a/config/Modules/Users/config/menus.dist.json
+++ b/config/Modules/Users/config/menus.dist.json
@@ -11,7 +11,6 @@
                     "label": "Users",
                     "desc": "Manage system users",
                     "url": "/users/",
-                    "icon": "user",
                     "order": 10
                 }
             ]

--- a/config/menu.php
+++ b/config/menu.php
@@ -4,7 +4,5 @@ return [
     'Menu' => [
         // call getMenu method only once
         'allControllers' => false,
-        // Default icon for menu item
-        'default_menu_item_icon' => 'cube',
     ],
 ];

--- a/src/Template/Element/aside-control-sidebar.ctp
+++ b/src/Template/Element/aside-control-sidebar.ctp
@@ -52,7 +52,7 @@ $hasActivity = false;
                 $config = (new ModuleConfig(ConfigType::MODULE(), Inflector::camelize($item['source'])))->parse();
 
                 $hasActivity = true;
-                $icon = isset($config->table->icon) ? $config->table->icon : Configure::read('Menu.default_menu_item_icon');
+                $icon = isset($config->table->icon) ? $config->table->icon : Configure::read('Menu.defaults.icon');
                 $title = isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($item['source']));
                 $heading = $factory->renderValue($table, $table->getDisplayField(), $entity->get($table->getDisplayField()), ['renderAs' => 'plain']);
                 ?>


### PR DESCRIPTION
This PR extends the work completed by #635 . In particular

* Remove icons from `menu.json`
* Drop hard-coded menu defaults
* Uses methods and defaults provided by `MenuFactory`

The above depend on changes introduced by https://github.com/QoboLtd/cakephp-menu/pull/105

