### PR TITLE
CakePHP 3.6 preparations (task #8175)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,11 @@
     "require": {
         "aws/aws-sdk-php": "^3.52",
         "brainmaestro/composer-git-hooks": "^2.4",
-        "cakephp/migrations": "^1.6",
+        "cakephp/cakephp": "^3.5 <3.6",
         "cakephp/plugin-installer": "^1.1",
         "dereuromark/cakephp-databaselog": "^2.1",
         "dereuromark/cakephp-whoops": "^0.1.2",
-        "josegonzalez/dotenv": "^3.2",
         "lasserafn/php-initial-avatar-generator": "^2.3",
-        "mobiledetect/mobiledetectlib": "2.*",
         "pelago/emogrifier": "^1.2",
         "pyrech/composer-changelogs": "^1.4",
         "qobo/cakephp-csv-migrations": "^32.0",
@@ -41,7 +39,7 @@
         "qobo/cakephp-menu": "^15.0",
         "qobo/cakephp-roles-capabilities": "^17.0",
         "qobo/cakephp-search": "^19.0",
-        "qobo/cakephp-utils": "^9.0",
+        "qobo/cakephp-utils": "^9.1",
         "qobo/qobo-robo": "^2.0",
         "qobo/qobo-robo-cakephp": "^2.0"
     },


### PR DESCRIPTION
* Moved some of the CakePHP composer requirements to the
  `cakephp-utils` plugin (v9.1.0).
* Locked down CakePHP version to the latest in v3.5, until we
  are ready to work on CakePHP 3.6