### PR TITLE
Switch qobo/cakephp-composer-dev v1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,18 +44,10 @@
         "qobo/qobo-robo-cakephp": "^2.0"
     },
     "require-dev": {
-        "cakephp/bake": "^1.1",
-        "cakephp/cakephp-codesniffer": "^3.0",
-        "phpstan/phpstan": "^0.10.3",
-        "phpunit/phpunit": "^6.0",
-        "psy/psysh": "@stable",
-        "thecodingmachine/phpstan-strict-rules": "^0.10.3",
-        "timeweb/phpstan-enum": "^2.0"
+        "qobo/cakephp-composer-dev": "v1.0"
     },
     "suggest": {
-        "ext-xdebug": "Allows code coverage reports and advanced debugging",
-        "markstory/asset_compress": "An asset compression plugin which provides file concatenation and a flexible filter system for preprocessing and minification.",
-        "dereuromark/cakephp-ide-helper": "After baking your code, this keeps your annotations in sync with the code evolving from there on for maximum IDE and PHPStan compatibility."
+        "markstory/asset_compress": "An asset compression plugin which provides file concatenation and a flexible filter system for preprocessing and minification."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In order to simplify the developer requirements across all the
CakePHP projects (project-template-cakephp, CakePHP plugins, etc
we now use a common composer metapackage to install require-dev
packages).