### PR TITLE
CronShell fix (task #7968)

### DIFF
--- a/src/Shell/CronShell.php
+++ b/src/Shell/CronShell.php
@@ -118,7 +118,7 @@ class CronShell extends Shell
      */
     public function lock(string $file, string $class)
     {
-        $class = str_replace([':', '/'], ['_', '_'], $class);
+        $class = preg_replace('/[^\da-z]/i', '_', $class);
         $lockFile = $this->Lock->getLockFileName($file, $class);
 
         try {

--- a/src/Shell/CronShell.php
+++ b/src/Shell/CronShell.php
@@ -118,7 +118,7 @@ class CronShell extends Shell
      */
     public function lock(string $file, string $class)
     {
-        $class = str_replace(':', '_', $class);
+        $class = str_replace([':', '/'], ['_', '_'], $class);
         $lockFile = $this->Lock->getLockFileName($file, $class);
 
         try {

--- a/tests/TestCase/Shell/CronShellTest.php
+++ b/tests/TestCase/Shell/CronShellTest.php
@@ -65,4 +65,29 @@ class CronShellTest extends ConsoleIntegrationTestCase
         $this->exec('cron');
         $this->assertExitCode(Shell::CODE_SUCCESS);
     }
+
+    /**
+     * @dataProvider fileAndClassNamesProvider
+     * @return void
+     */
+    public function testLock($file, $class, $normalized) : void
+    {
+        $this->exec(sprintf('cron lock %s %s', $file, $class));
+
+        $expected = sprintf('%s%s_%s.lock.lock', sys_get_temp_dir() . DS, $normalized, md5($file));
+        $this->assertTrue(file_exists($expected));
+    }
+
+    public function fileAndClassNamesProvider() : array
+    {
+        return [
+            ['foo', 'bar', 'bar'],
+            ['foo1', 'bar1', 'bar1'],
+            ['foo_1234', 'bar__1', 'bar__1'],
+            ['foo\1234', 'b*a@r!5', 'b_a_r_5'],
+            ['foos', null, ''],
+            ['foos', '', ''],
+            ['foos', '1', '1']
+        ];
+    }
 }


### PR DESCRIPTION
Replace slashes with underscores when generating lock files for plugin shell tasks with a vendor prefix. Otherwise, lock-file will be treated as sub-directory and will always fail to execute the relevant task.