### PR TITLE
CakePHP 3.6 deprecated errors (task #8244)

### DIFF
--- a/src/Auth/LdapAuthenticate.php
+++ b/src/Auth/LdapAuthenticate.php
@@ -80,6 +80,7 @@ class LdapAuthenticate extends BaseAuthenticate
     protected function _connect()
     {
         try {
+            // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
             $this->_connection = @ldap_connect($this->_config['host'], $this->_config['port']);
             // set LDAP options
             ldap_set_option($this->_connection, LDAP_OPT_PROTOCOL_VERSION, (int)$this->_config['version']);
@@ -100,6 +101,7 @@ class LdapAuthenticate extends BaseAuthenticate
         }
 
         try {
+            // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
             $bind = @ldap_bind($this->_connection, $request->data['username'], $request->data['password']);
             if ($bind) {
                 $filter = '(' . $this->_config['filter'] . '=' . $request->data['username'] . ')';
@@ -211,7 +213,9 @@ class LdapAuthenticate extends BaseAuthenticate
      */
     protected function _disconnect()
     {
+        // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
         @ldap_unbind($this->_connection);
+        // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
         @ldap_close($this->_connection);
     }
 }

--- a/src/Controller/Api/V1/V0/AppController.php
+++ b/src/Controller/Api/V1/V0/AppController.php
@@ -114,7 +114,7 @@ class AppController extends Controller
     protected function enableAuthorization(): void
     {
         $user = empty($this->Auth->user()) ? [] : $this->Auth->user();
-        $hasAccess = $this->_checkAccess($this->request->getParam(), $user);
+        $hasAccess = $this->_checkAccess($this->request->getAttribute('params'), $user);
 
         if (!$hasAccess) {
             throw new ForbiddenException();

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -127,7 +127,7 @@ class AppController extends Controller
         $this->_allowedResetPassword();
 
         // if user not logged in, redirect him to login page
-        $url = $event->getSubject()->request->params;
+        $url = $event->getSubject()->request->getAttribute('params');
         try {
             $user = empty($this->Auth->user()) ? [] : $this->Auth->user();
             $result = $this->_checkAccess($url, $user);
@@ -314,7 +314,7 @@ class AppController extends Controller
         ];
 
         // skip if url does not match Users requestResetPassword action.
-        if (array_diff_assoc($url, $this->request->params)) {
+        if (array_diff_assoc($url, $this->request->getAttribute('params'))) {
             return;
         }
 
@@ -359,7 +359,7 @@ class AppController extends Controller
         $renderIframe = trim((string)getenv('ALLOW_IFRAME_RENDERING'));
 
         if ('' !== $renderIframe) {
-            $this->response->header('X-Frame-Options', $renderIframe);
+            $this->setResponse($this->response->withHeader('X-Frame-Options', $renderIframe));
         }
     }
 

--- a/src/Event/Plugin/Menu/View/ModuleIndexListener.php
+++ b/src/Event/Plugin/Menu/View/ModuleIndexListener.php
@@ -61,8 +61,8 @@ class ModuleIndexListener implements EventListenerInterface
      */
     private function getBatchMenuItem(ServerRequest $request)
     {
-        $plugin = $request->param('plugin');
-        $controller = $request->param('controller');
+        $plugin = $request->getParam('plugin');
+        $controller = $request->getParam('controller');
 
         $batchItem = MenuItemFactory::createMenuItem([
             'type' => 'button',
@@ -110,8 +110,8 @@ class ModuleIndexListener implements EventListenerInterface
      */
     private function getImportMenuItem(ServerRequest $request)
     {
-        $plugin = $request->param('plugin');
-        $controller = $request->param('controller');
+        $plugin = $request->getParam('plugin');
+        $controller = $request->getParam('controller');
 
         return MenuItemFactory::createMenuItem([
             'url' => ['plugin' => $plugin, 'controller' => $controller, 'action' => 'import'],
@@ -130,8 +130,8 @@ class ModuleIndexListener implements EventListenerInterface
      */
     private function getAddMenuItem(ServerRequest $request)
     {
-        $plugin = $request->param('plugin');
-        $controller = $request->param('controller');
+        $plugin = $request->getParam('plugin');
+        $controller = $request->getParam('controller');
 
         return MenuItemFactory::createMenuItem([
             'url' => ['plugin' => $plugin, 'controller' => $controller, 'action' => 'add'],
@@ -151,7 +151,7 @@ class ModuleIndexListener implements EventListenerInterface
     private function getDelLogItem(ServerRequest $request)
     {
         $age = Configure::read('ScheduledLog.stats.age');
-        $controller = $request->param('controller');
+        $controller = $request->getParam('controller');
 
         $delLog = MenuItemFactory::createMenuItem([
             'url' => ['plugin' => false, 'controller' => 'ScheduledJobLogs', 'action' => 'gc'],


### PR DESCRIPTION
- Few more fixes for CakePHP 3.6 deprecated errors
- Ignore phpcs silencing warnings for LDAP related functions