### PR TITLE
Upgrade to project-update v10.3.1

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -22,7 +22,8 @@ $useOnlyCookies = (bool)env('APP_SESSION_USE_ONLY_COOKIES', true);
 $sessionTimeout = (int)env('APP_SESSION_TIMEOUT', 43200);
 
 // Ignore deprecated errors when debug is disabled.
-$errorLevel = $debug ? E_ALL : E_ALL & ~E_DEPRECATED;
+// INFO: this has been modified until all deprecated CakePHP 3.6 errors are fixed.
+$errorLevel = E_ALL ^ E_USER_DEPRECATED;
 
 // If EMAIL_ENABLED is false, use Debug transport.  Otherwise, use
 // either the Smtp transport if enabled or fallback on Mail transport.


### PR DESCRIPTION
Additionally, we adjusted app configuration to ignore CakePHP 3.6 deprecated errors,
as suggested by CakePHP:
https://book.cakephp.org/3.next/en/appendices/3-6-migration-guide.html#disabling-deprecation-warnings