### PR TITLE
Skip default and swagger cache (task #2555)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -104,6 +104,9 @@ if (Configure::read('debug')) {
     Configure::write('Cache._cake_core_.duration', '+2 minutes');
     // disable router cache during development
     Configure::write('Cache._cake_routes_.duration', '+2 seconds');
+
+    Configure::write('Cache._cake_swagger_.duration', '+2 seconds');
+    Configure::write('Cache.default.duration', '+2 seconds');
 }
 
 /*


### PR DESCRIPTION
Applicable only when in development, default and swagger cache have a duration of 2 seconds.
The implementation is identical to routing caching. Another solution is to completely disabling cache.
