### PR TITLE
Bugfix for empty result set on API lookup endpoint (task #8734)

### DIFF
--- a/src/Event/Controller/Api/LookupActionListener.php
+++ b/src/Event/Controller/Api/LookupActionListener.php
@@ -359,8 +359,8 @@ class LookupActionListener extends BaseActionListener
         $query->join([
             'table' => $targetTable->table(),
             'alias' => $parentAssociation->name(),
-            'type' => 'INNER',
-            'conditions' => $foreignKey . ' = ' . $primaryKey . ' OR ' . $foreignKey . ' IS NULL'
+            'type' => 'LEFT',
+            'conditions' => [$foreignKey => $primaryKey]
         ]);
 
         $this->_joinParentTables($targetTable, $query);


### PR DESCRIPTION
Switched to left join to include results with NULL foreign keys.