### PR TITLE
Re-add cakephp/bake to non-dev dependencies (task #8927)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "require": {
         "aws/aws-sdk-php": "^3.52",
         "brainmaestro/composer-git-hooks": "^2.4",
+        "cakephp/bake": "^1.8",
         "cakephp/cakephp": "^3.6",
         "cakephp/plugin-installer": "^1.1",
         "composer/composer": "^1.7",


### PR DESCRIPTION
We usually install `cakephp/bake` as developer requirement on all
development and test environments.  In production, however, running
`composer install --no-dev` skips bake altogether.  This is fine for
most other projects, but not for us.

One of our migration scripts (`src/Shell/Task/UpgradeFileTask.php`)
requires the presence of bake and breaks the deployment during the
`app:update` if it's not there.