### PR TITLE
Tests improvements (task #8712)

### DIFF
--- a/tests/TestCase/Event/LookupActionListenerTest.php
+++ b/tests/TestCase/Event/LookupActionListenerTest.php
@@ -38,7 +38,7 @@ class LookupActionListenerTest extends TestCase
 
         $listener = new LookupActionListener();
         $listener->beforeLookup($event, $query);
-        $this->assertEquals(10, $query->count());
+        $this->assertFalse($query->isEmpty());
     }
 
     public function testBeforeLookupWithQuery(): void

--- a/tests/TestCase/Event/LookupActionListenerTest.php
+++ b/tests/TestCase/Event/LookupActionListenerTest.php
@@ -16,6 +16,8 @@ class LookupActionListenerTest extends TestCase
 
     public $fixtures = [
         'app.users',
+        'plugin.Groups.groups',
+        'plugin.Groups.groups_users',
     ];
 
     public function setUp()


### PR DESCRIPTION
Since we are testing `beforeLookup` event, we cannot rely on pagination limit, which is only applied later on. The test was passing with the old assertion because the users' fixture includes exactly 10 records. But if a record is added or removed it will fail. We now simply assert that the query is not empty.