### PR TITLE
Allow using default index methods for child controllers (task #9785)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -214,7 +214,7 @@ class AppController extends Controller
      *
      * @return \Cake\Datasource\EntityInterface
      */
-    private function getSystemSearch(): EntityInterface
+    protected function getSystemSearch(): EntityInterface
     {
         $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
 
@@ -236,7 +236,7 @@ class AppController extends Controller
      *
      * @return \Cake\Datasource\EntityInterface
      */
-    private function createSystemSearch(): EntityInterface
+    protected function createSystemSearch(): EntityInterface
     {
         $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
         /**


### PR DESCRIPTION
Expanding visibility of `getSystemSearch()` and `createSystemSearch()` from `private` to `protected`, so we could use these methods in child controllers, whenever we need to overwrite `index()` method.