### PR TITLE
As we overwrite default plugin controller U2f has to be imported (task #9997)

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -6,6 +6,7 @@ use CakeDC\Users\Controller\Traits\LoginTrait;
 use CakeDC\Users\Controller\Traits\ProfileTrait;
 use CakeDC\Users\Controller\Traits\RegisterTrait;
 use CakeDC\Users\Controller\Traits\SimpleCrudTrait;
+use CakeDC\Users\Controller\Traits\U2fTrait;
 use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Exception\WrongPasswordException;
 use Cake\Http\Exception\ForbiddenException;
@@ -28,6 +29,7 @@ class UsersController extends AppController
     use SimpleCrudTrait {
         SimpleCrudTrait::delete as defaultDelete;
     }
+    use U2fTrait;
 
     /**
      * changeUserPassword method


### PR DESCRIPTION
- U2F middleware is added to do two-step auth for the `cakedc/users` plugin `v8.1.0`.

As we overwrite `UsersController` on the template level, we have to use `U2fTrait` so it will be disabled automatically via `initialise()`.