### PR TITLE
IN clause suppor (task #9659)

### DIFF
--- a/src/Event/Controller/Api/IndexActionListener.php
+++ b/src/Event/Controller/Api/IndexActionListener.php
@@ -106,7 +106,11 @@ class IndexActionListener extends BaseActionListener
 
         $conditions = [];
         foreach ($queryParam as $field => $value) {
-            $conditions[$table->aliasField($field)] = $value;
+            $key = $table->aliasField($field);
+            if (is_array($value)) {
+                $key .= ' IN';
+            }
+            $conditions[$key] = $value;
         };
 
         $query->applyOptions(['conditions' => $conditions]);

--- a/tests/TestCase/Controller/Api/V1/V0/UsersControllerTest.php
+++ b/tests/TestCase/Controller/Api/V1/V0/UsersControllerTest.php
@@ -198,5 +198,16 @@ class UsersControllerTest extends IntegrationTestCase
         $entity = $this->Users->get($id);
 
         $this->assertEquals($data['first_name'], $entity->get('first_name'));
+
+        $this->setAuthHeaders('00000000-0000-0000-0000-000000000002');
+        $this->get('/api/users/index.json?conditions[username][]=foo&conditions[username][]=user-1');
+        $this->assertResponseOk();
+
+        $body = $this->_response->getBody();
+        $response = json_decode($body);
+
+        $entity = $this->Users->get($id);
+
+        $this->assertEquals($data['first_name'], $entity->get('first_name'));
     }
 }

--- a/tests/TestCase/Controller/Api/V1/V0/UsersControllerTest.php
+++ b/tests/TestCase/Controller/Api/V1/V0/UsersControllerTest.php
@@ -198,7 +198,10 @@ class UsersControllerTest extends IntegrationTestCase
         $entity = $this->Users->get($id);
 
         $this->assertEquals($data['first_name'], $entity->get('first_name'));
+    }
 
+    public function testIndexWithArrayConditions(): void
+    {
         $this->setAuthHeaders('00000000-0000-0000-0000-000000000002');
         $this->get('/api/users/index.json?conditions[username][]=foo&conditions[username][]=user-1');
         $this->assertResponseOk();
@@ -206,8 +209,9 @@ class UsersControllerTest extends IntegrationTestCase
         $body = $this->_response->getBody();
         $response = json_decode($body);
 
+        $id = '00000000-0000-0000-0000-000000000001';
         $entity = $this->Users->get($id);
 
-        $this->assertEquals($data['first_name'], $entity->get('first_name'));
+        $this->assertEquals('first1', $entity->get('first_name'));
     }
 }


### PR DESCRIPTION
IN clause support in conditions for API "index" endpoint. This will allow passing multiple values for a single column, using the following query string:
`/api/leads.json?conditions[name][]=foo&conditions[name][]=bar`
Will be converted to the following where clause:
`$conditions = [
    'Leads.name IN' => ['foo', 'bar']
];`