### PR TITLE
Changed the way it shows the foreign keys on related tabs (Task #10250)

### DIFF
--- a/src/Template/Plugin/CsvMigrations/Element/Associated/tabs-list.ctp
+++ b/src/Template/Plugin/CsvMigrations/Element/Associated/tabs-list.ctp
@@ -30,7 +30,14 @@ $setLabels = [];
         }
 
         if (in_array($label, $setLabels)) {
-            $label .= ' (' . $association->getForeignKey() . ')';
+            $mcFields = new ModuleConfig(ConfigType::FIELDS(), $tableName);
+            $configFields = $mcFields->parseToArray();
+
+            if (array_key_exists($association->getForeignKey(),$configFields) && array_key_exists('label',$configFields[$association->getForeignKey()]) ) {
+                $label .= ' (' . $configFields[$association->getForeignKey()]['label'] . ')';
+            }else{
+                $label .= ' (' . Inflector::humanize(Inflector::delimit($association->getForeignKey())) . ')';
+            }
         }
 
         $setLabels[] = $label;


### PR DESCRIPTION
Changed the way it shows the foreign keys on related tabs to be more user friendly, it reads the labels from fields file and in case the foreign key is not there then it use the Inflector::humanize 