### PR TITLE
Back-porting fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "require": {
         "aws/aws-sdk-php": "^3.52",
         "brainmaestro/composer-git-hooks": "^2.4",
+        "cakedc/users": "~8.1.0",
         "cakephp/cakephp": "^3.6",
         "cakephp/plugin-installer": "^1.1",
         "composer/composer": "^1.7",

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -180,7 +180,7 @@ class AppController extends Controller
     public function index()
     {
         $entity = $this->getSystemSearch();
-        $searchData = json_decode($entity->get('content'), true);
+        $searchData = $entity->get('content');
 
         // return json response and skip any further processing.
         if ($this->request->is('ajax') && $this->request->accepts('application/json')) {

--- a/src/Event/Plugin/Search/Model/SearchableFieldsListener.php
+++ b/src/Event/Plugin/Search/Model/SearchableFieldsListener.php
@@ -256,7 +256,6 @@ class SearchableFieldsListener implements EventListenerInterface
         try {
             $mc = new ModuleConfig(ConfigType::MODULE(), $table->getRegistryAlias());
             $config = $mc->parseToArray();
-            // $config = json_decode(json_encode($config), true);
         } catch (InvalidArgumentException $e) {
             Log::error($e);
         }
@@ -291,7 +290,7 @@ class SearchableFieldsListener implements EventListenerInterface
          */
         $entity = $query->first();
 
-        $searchData = json_decode($entity->get('content'));
+        $searchData = $entity->get('content');
 
         return (array)$searchData->saved->display_columns;
     }

--- a/src/Event/Plugin/Search/Model/SearchableFieldsListener.php
+++ b/src/Event/Plugin/Search/Model/SearchableFieldsListener.php
@@ -292,7 +292,11 @@ class SearchableFieldsListener implements EventListenerInterface
 
         $searchData = $entity->get('content');
 
-        return (array)$searchData->saved->display_columns;
+        if (! isset($searchData['saved']['display_columns'])) {
+            return [];
+        }
+
+        return (array)$searchData['saved']['display_columns'];
     }
 
     /**

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -83,7 +83,7 @@ class User extends BaseUser
 
         $capabilities = TableRegistry::get('RolesCapabilities.Capabilities');
         Assert::isInstanceOf($capabilities, CapabilitiesTable::class);
-        $userGroups = $capabilities->getUserGroups($this->get('id'));
+        $userGroups = $capabilities->getUserGroups((string)$this->get('id'));
         $userRoles = $capabilities->getGroupsRoles($userGroups);
         $isAdmin = in_array($roleName, $userRoles);
 

--- a/src/Shell/Task/Upgrade20190315152328Task.php
+++ b/src/Shell/Task/Upgrade20190315152328Task.php
@@ -1,0 +1,38 @@
+<?php
+namespace App\Shell\Task;
+
+use Cake\Console\ConsoleOptionParser;
+use Cake\Console\Shell;
+use Cake\I18n\Time;
+
+/**
+ *  Adds scheduled job for running pre-saved searches cleanup once a day.
+ */
+class Upgrade20190315152328Task extends Shell
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = new ConsoleOptionParser('console');
+
+        return $parser;
+    }
+
+    /**
+     * Main method.
+     *
+     * @return void
+     */
+    public function main()
+    {
+        $task = $this->Tasks->load('ScheduledJobs');
+
+        $task->add('CakeShell::Search:search', [
+            'recurrence' => 'FREQ=DAILY;INTERVAL=1',
+            'start_date' => new Time('now'),
+            'options' => 'cleanup'
+        ]);
+    }
+}

--- a/src/Template/Plugin/Search/Element/Search/Forms/save_search.ctp
+++ b/src/Template/Plugin/Search/Element/Search/Forms/save_search.ctp
@@ -18,9 +18,9 @@ if ($accessFactory->hasAccess($url, $user)) : ?>
         'url' => [
             'plugin' => $this->request->getParam('plugin'),
             'controller' => $this->request->getParam('controller'),
-            'action' => ($isEditable ? 'edit': 'save') . '-search',
+            'action' => ($savedSearch->get('is_editable') ? 'edit': 'save') . '-search',
             $preSaveId,
-            $isEditable ? $savedSearch->id : null
+            $savedSearch->get('is_editable') ? $savedSearch->id : null
         ]
     ]); ?>
     <div class="input-group">
@@ -29,7 +29,7 @@ if ($accessFactory->hasAccess($url, $user)) : ?>
             'class' => 'form-control input-sm',
             'placeholder' => 'Save criteria name',
             'required' => true,
-            'value' => $isEditable ? $savedSearch->name : ''
+            'value' => $savedSearch->get('is_editable') ? $savedSearch->name : ''
         ]); ?>
         <span class="input-group-btn">
             <?= $this->Form->button(

--- a/src/Template/Plugin/Search/Search/search.ctp
+++ b/src/Template/Plugin/Search/Search/search.ctp
@@ -20,7 +20,6 @@ echo $this->element('Search.Search/filters', [
     'searchableFields' => $searchableFields,
     'savedSearch' => $savedSearch,
     'searchData' => $searchData,
-    'isEditable' => $isEditable,
     'preSaveId' => $preSaveId,
     'associationLabels' => $associationLabels
 ]);


### PR DESCRIPTION
- CakeDC users plugin is now locked to v8.1.*. There is an issue with CakeDC users tag 8.3.2, which actually points to an older version of the plugin (8.0.3) from the one we are currently using (8.1.0).
Additionally, the next release (8.2.0) requires CakePHP 3.7, which is currently a blocker for us.
- The logs search has been adjusted to comply with Search plugin upgrade.