### PR TITLE
Use Whoops middleware

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -14,7 +14,7 @@
  */
 namespace App;
 
-use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use CakephpWhoops\Error\Middleware\WhoopsHandlerMiddleware;
 use Cake\Http\BaseApplication;
 use Cake\Routing\Middleware\AssetMiddleware;
 use Cake\Routing\Middleware\RoutingMiddleware;
@@ -47,7 +47,7 @@ class Application extends BaseApplication
         $middlewareQueue
             // Catch any exceptions in the lower layers,
             // and make an error page/response
-            ->add(ErrorHandlerMiddleware::class)
+            ->add(WhoopsHandlerMiddleware::class)
 
             // Handle plugin/theme assets like CakePHP normally does.
             ->add(AssetMiddleware::class)


### PR DESCRIPTION
This replaces the CakePHP Error middlware with Whoops, to fix the inconsistency in errors reporting.
