### PR TITLE
Use SVG URL Loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "node-sass": "^4.9.0",
     "rrule": "^2.2.0",
     "sass-loader": "^7.0.1",
+    "svg-url-loader": "^2.3.2",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "vue": "^2.5.2",
     "vue-select": "^2.5.1",

--- a/resources/build/webpack.base.conf.js
+++ b/resources/build/webpack.base.conf.js
@@ -30,10 +30,16 @@ module.exports = {
         exclude: /node_modules/
       },
       {
-        test: /\.(png|jpg|gif|svg)$/,
+        test: /\.(png|jpg|gif)$/,
         loader: 'file-loader',
         options: {
           name: '[name].[ext]?[hash]'
+        }
+      },
+      {
+        test: /\.(svg)$/,
+        loader: 'svg-url-loader',
+        options: {
         }
       },
       {


### PR DESCRIPTION
Loads SVG file as utf-8 encoded DataUrl string.

This also resolves the issue of getting corrupted files when there are more than one SVGs with the same name. For example, in module flag-icon-svg package flag are available in two different sizes (1x1, 4x3) causing random corruptions in file contents.
