### PR TITLE
Add the model name in the savedSearch widgets (task #11098)

### DIFF
--- a/src/Utility/Search.php
+++ b/src/Utility/Search.php
@@ -166,6 +166,7 @@ final class Search
                 case 'pie':
                     $widget = new $chart['class'];
                     $widget->setConfig([
+                        'modelName' => $savedSearch->get('model'),
                         'info' => [
                             'columns' => implode(',', [SearchService::GROUP_BY_FIELD, $groupBy]),
                             'x_axis' => $groupBy,


### PR DESCRIPTION
For future operations on the widget before the rendering, we need the `modelName` as is set for the static reports.