### PR TITLE
CI performance improvement (task #11384)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - ./bin/composer install --no-interaction --no-progress --no-suggest
   - yarn install
   - mkdir -p build/test-coverage build/test-results
-  - ./bin/build app:install CHOWN_USER=$USER,CHGRP_GROUP=$USER,DB_NAME=app,DB_ADMIN_USER=root,DB_USER=root --quick
+  - ./bin/build app:install CHOWN_USER=$USER,CHGRP_GROUP=$USER,DB_NAME=app,DB_ADMIN_USER=root,DB_USER=root --skip-test-db
 
 before_script:
   - ./bin/phpserv >/dev/null 2>&1 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - ./bin/composer install --no-interaction --no-progress --no-suggest
   - yarn install
   - mkdir -p build/test-coverage build/test-results
-  - ./bin/build app:install CHOWN_USER=$USER,CHGRP_GROUP=$USER,DB_NAME=app,DB_ADMIN_USER=root,DB_USER=root
+  - ./bin/build app:install CHOWN_USER=$USER,CHGRP_GROUP=$USER,DB_NAME=app,DB_ADMIN_USER=root,DB_USER=root --quick
 
 before_script:
   - ./bin/phpserv >/dev/null 2>&1 &

--- a/build/Robo/Command/App/App.php
+++ b/build/Robo/Command/App/App.php
@@ -20,10 +20,11 @@ class App extends AbstractCommand
      * Install a project
      *
      * @param string $env Custom env in KEY1=VALUE1,KEY2=VALUE2 format
-     *
+     * @param array $options Command options
+     * @option $quick Quick synchronization mode
      * @return bool true on success or false on failure
      */
-    public function appInstall($env = '')
+    public function appInstall($env = '', array $options = ['quick' => false])
     {
         $env = $this->getDotenv($env);
 
@@ -31,7 +32,7 @@ class App extends AbstractCommand
             $this->exitError("Failed to do pre-install ");
         }
 
-        $result = $this->installCake($env);
+        $result = $this->installCake($env, $options);
 
         if (!$result) {
             $this->exitError("Failed to do app:install");
@@ -48,10 +49,11 @@ class App extends AbstractCommand
      * Update a project
      *
      * @param string $env Custom env in KEY1=VALUE1,KEY2=VALUE2 format
-     *
+     * @param array $options Command options
+     * @option $quick Quick synchronization mode
      * @return bool true on success or false on failure
      */
-    public function appUpdate($env = '')
+    public function appUpdate($env = '', array $options = ['quick' => false])
     {
         $env = $this->getDotenv($env);
 
@@ -59,7 +61,7 @@ class App extends AbstractCommand
             $this->exitError("Failed to do app:update");
         }
 
-        $result = $this->updateCake($env);
+        $result = $this->updateCake($env, $options);
 
         if (!$result) {
             $this->exitError("Failed to do app:update");
@@ -121,9 +123,10 @@ class App extends AbstractCommand
      * Do CakePHP related install things
      *
      * @param array $env Environment
+     * @param array $options Command options
      * @return bool true on success or false on failure
      */
-    protected function installCake($env)
+    protected function installCake($env, array $options)
     {
         // Check DB connectivity and get server time
         $result = $this->taskMysqlBaseQuery()
@@ -182,32 +185,34 @@ class App extends AbstractCommand
         }
         $plugins = $result->getData()['data'];
 
-        // test plugin migrations
-        foreach ($plugins as $plugin) {
+        if (! (bool)$options['quick']) {
+            // test plugin migrations
+            foreach ($plugins as $plugin) {
+                $tasks[] = $this->taskCakephpMigration()
+                    ->connection('test')
+                    ->plugin($plugin);
+            }
+
+            // test app migration
             $tasks[] = $this->taskCakephpMigration()
-                ->connection('test')
-                ->plugin($plugin);
+                ->connection('test');
+
+            // drop test DB
+            $tasks[] = $this->taskMysqlDbDrop()
+                 ->db($this->getValue('DB_NAME', $env) . "_test")
+                 ->user($this->getValue('DB_ADMIN_USER', $env))
+                 ->pass($this->getValue('DB_ADMIN_PASS', $env))
+                 ->hide($this->getValue('DB_ADMIN_PASS', $env))
+                 ->host($this->getValue('DB_HOST', $env));
+
+            // create test DB
+            $tasks[] = $this->taskMysqlDbCreate()
+                ->db($this->getValue('DB_NAME', $env) . "_test")
+                ->user($this->getValue('DB_ADMIN_USER', $env))
+                ->pass($this->getValue('DB_ADMIN_PASS', $env))
+                ->hide($this->getValue('DB_ADMIN_PASS', $env))
+                ->host($this->getValue('DB_HOST', $env));
         }
-
-        // test app migration
-        $tasks[] = $this->taskCakephpMigration()
-            ->connection('test');
-
-        // drop test DB
-        $tasks[] = $this->taskMysqlDbDrop()
-             ->db($this->getValue('DB_NAME', $env) . "_test")
-             ->user($this->getValue('DB_ADMIN_USER', $env))
-             ->pass($this->getValue('DB_ADMIN_PASS', $env))
-             ->hide($this->getValue('DB_ADMIN_PASS', $env))
-             ->host($this->getValue('DB_HOST', $env));
-
-        // create test DB
-        $tasks[] = $this->taskMysqlDbCreate()
-            ->db($this->getValue('DB_NAME', $env) . "_test")
-            ->user($this->getValue('DB_ADMIN_USER', $env))
-            ->pass($this->getValue('DB_ADMIN_PASS', $env))
-            ->hide($this->getValue('DB_ADMIN_PASS', $env))
-            ->host($this->getValue('DB_HOST', $env));
 
         // cleanup database logs
         $tasks[] = $this->taskCakephpShellScript()->name('database_log')->param('gc');
@@ -264,9 +269,10 @@ class App extends AbstractCommand
      * Do CakePHP related update things
      *
      * @param array $env Environment
+     * @param array $options Command options
      * @return bool true on success or false on failure
      */
-    protected function updateCake($env)
+    protected function updateCake($env, array $options)
     {
         // Check DB connectivity and get server time
         $result = $this->taskMysqlBaseQuery()
@@ -320,32 +326,34 @@ class App extends AbstractCommand
         }
         $plugins = $result->getData()['data'];
 
-        // test plugin migrations
-        foreach ($plugins as $plugin) {
+        if (! (bool)$options['quick']) {
+            // test plugin migrations
+            foreach ($plugins as $plugin) {
+                $tasks[] = $this->taskCakephpMigration()
+                    ->connection('test')
+                    ->plugin($plugin);
+            }
+
+            // test app migration
             $tasks[] = $this->taskCakephpMigration()
-                ->connection('test')
-                ->plugin($plugin);
+                ->connection('test');
+
+            // drop test DB
+            $tasks[] = $this->taskMysqlDbDrop()
+                 ->db($this->getValue('DB_NAME', $env) . "_test")
+                 ->user($this->getValue('DB_ADMIN_USER', $env))
+                 ->pass($this->getValue('DB_ADMIN_PASS', $env))
+                 ->hide($this->getValue('DB_ADMIN_PASS', $env))
+                 ->host($this->getValue('DB_HOST', $env));
+
+            // create test DB
+            $tasks[] = $this->taskMysqlDbCreate()
+                ->db($this->getValue('DB_NAME', $env) . "_test")
+                ->user($this->getValue('DB_ADMIN_USER', $env))
+                ->pass($this->getValue('DB_ADMIN_PASS', $env))
+                ->hide($this->getValue('DB_ADMIN_PASS', $env))
+                ->host($this->getValue('DB_HOST', $env));
         }
-
-        // test app migration
-        $tasks[] = $this->taskCakephpMigration()
-            ->connection('test');
-
-        // drop test DB
-        $tasks[] = $this->taskMysqlDbDrop()
-             ->db($this->getValue('DB_NAME', $env) . "_test")
-             ->user($this->getValue('DB_ADMIN_USER', $env))
-             ->pass($this->getValue('DB_ADMIN_PASS', $env))
-             ->hide($this->getValue('DB_ADMIN_PASS', $env))
-             ->host($this->getValue('DB_HOST', $env));
-
-        // create test DB
-        $tasks[] = $this->taskMysqlDbCreate()
-            ->db($this->getValue('DB_NAME', $env) . "_test")
-            ->user($this->getValue('DB_ADMIN_USER', $env))
-            ->pass($this->getValue('DB_ADMIN_PASS', $env))
-            ->hide($this->getValue('DB_ADMIN_PASS', $env))
-            ->host($this->getValue('DB_HOST', $env));
 
         // cleanup database logs
         $tasks[] = $this->taskCakephpShellScript()->name('database_log')->param('gc');

--- a/build/Robo/Command/App/App.php
+++ b/build/Robo/Command/App/App.php
@@ -21,10 +21,10 @@ class App extends AbstractCommand
      *
      * @param string $env Custom env in KEY1=VALUE1,KEY2=VALUE2 format
      * @param array $options Command options
-     * @option $quick Quick synchronization mode
+     * @option $skip-test-db Skip test database migrations
      * @return bool true on success or false on failure
      */
-    public function appInstall($env = '', array $options = ['quick' => false])
+    public function appInstall($env = '', array $options = ['skip-test-db' => false])
     {
         $env = $this->getDotenv($env);
 
@@ -50,10 +50,10 @@ class App extends AbstractCommand
      *
      * @param string $env Custom env in KEY1=VALUE1,KEY2=VALUE2 format
      * @param array $options Command options
-     * @option $quick Quick synchronization mode
+     * @option $skip-test-db Skip test database migrations
      * @return bool true on success or false on failure
      */
-    public function appUpdate($env = '', array $options = ['quick' => false])
+    public function appUpdate($env = '', array $options = ['skip-test-db' => false])
     {
         $env = $this->getDotenv($env);
 
@@ -185,7 +185,7 @@ class App extends AbstractCommand
         }
         $plugins = $result->getData()['data'];
 
-        if (! (bool)$options['quick']) {
+        if (! (bool)$options['skip-test-db']) {
             // test plugin migrations
             foreach ($plugins as $plugin) {
                 $tasks[] = $this->taskCakephpMigration()
@@ -326,7 +326,7 @@ class App extends AbstractCommand
         }
         $plugins = $result->getData()['data'];
 
-        if (! (bool)$options['quick']) {
+        if (! (bool)$options['skip-test-db']) {
             // test plugin migrations
             foreach ($plugins as $plugin) {
                 $tasks[] = $this->taskCakephpMigration()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       && ./bin/composer validate --strict
       && ./bin/composer install --no-progress --no-suggest
       && ./vendor/bin/phpcs
-      && ./bin/build app:install CHOWN_USER=root,CHGRP_GROUP=root,DB_HOST=mysql,DB_NAME=app,DB_ADMIN_USER=root,DB_ADMIN_PASS=root,DB_USER=root,DB_PASS=root --quick
+      && ./bin/build app:install CHOWN_USER=root,CHGRP_GROUP=root,DB_HOST=mysql,DB_NAME=app,DB_ADMIN_USER=root,DB_ADMIN_PASS=root,DB_USER=root,DB_PASS=root --skip-test-db
       && ./vendor/bin/phpunit --group example --no-coverage
       && ./vendor/bin/phpunit --exclude-group example,external --no-coverage"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       && ./bin/composer validate --strict
       && ./bin/composer install --no-progress --no-suggest
       && ./vendor/bin/phpcs
-      && ./bin/build app:install CHOWN_USER=root,CHGRP_GROUP=root,DB_HOST=mysql,DB_NAME=app,DB_ADMIN_USER=root,DB_ADMIN_PASS=root,DB_USER=root,DB_PASS=root
+      && ./bin/build app:install CHOWN_USER=root,CHGRP_GROUP=root,DB_HOST=mysql,DB_NAME=app,DB_ADMIN_USER=root,DB_ADMIN_PASS=root,DB_USER=root,DB_PASS=root --quick
       && ./vendor/bin/phpunit --group example --no-coverage
       && ./vendor/bin/phpunit --exclude-group example,external --no-coverage"
     depends_on:


### PR DESCRIPTION
Currently, during a project installation/update, we first execute the CakePHP migrations against the test database to catch any errors before we run them against the live database.

This PR introduces a flag which is used to skip running migrations against the test database on CI builds since each build is run against a new environment without any pre-existing database data.

Listed below are some benchmarks run locally, executed three times for each case. The difference will dramatically increase in child projects where the number of tables is much greater.

Without `--quick` flag:
- 18.177s
- 19.495s
- 18.864s

With `--quick` flag:
- 11.243s
- 10.720s
- 11.139s