### PR TITLE
Remove HTML from config (task #11382)

### DIFF
--- a/config/admin_lte.php
+++ b/config/admin_lte.php
@@ -8,17 +8,13 @@
  * so it would be loaded locally.
  */
 
-// create logo HTML img tags
-$logo = '<img src="/img/logo.png" alt="Site Logo" height="50" />';
-$logoMini = '<img src="/img/logo-mini.png" alt="Site Logo"height="50" />';
-
 return [
     'Theme' => [
         'folder' => ROOT,
         'title' => getenv('PROJECT_NAME'),
         'logo' => [
-            'mini' => $logoMini,
-            'large' => $logo,
+            'mini' => 'logo-mini.png',
+            'large' => 'logo.png',
         ],
         'login' => [
             'show_remember' => true,

--- a/src/Template/Element/System/about-project.ctp
+++ b/src/Template/Element/System/about-project.ctp
@@ -15,7 +15,7 @@ $projectLogo = Project::getLogo('large');
         <h3 class="box-title">About</h3>
     </div>
     <div class="box-body">
-        <p><?= $projectLogo ?></p>
+        <p><img src="<?= $this->Url->image($projectLogo) ?>" alt="Site Logo" height="50" /></p>
         <p>Welcome to <b><?= $projectName ?></b>.  You are using version <b><?= $projectVersion ?></b>.
     </div>
 </div>

--- a/src/Template/Element/logo.ctp
+++ b/src/Template/Element/logo.ctp
@@ -1,6 +1,6 @@
 <?php
 use Cake\Core\Configure;
+
+$size = $size ?? 'large';
 ?>
-<a href="<?= $this->Url->build('/', ['fullBase' => true]); ?>">
-    <?= Configure::read('Theme.logo.large'); ?>
-</a>
+<img src="<?= $this->Url->image(Configure::read('Theme.logo.' . $size)) ?>" alt="Site Logo" height="50" />

--- a/src/Template/Layout/AdminLTE/login.ctp
+++ b/src/Template/Layout/AdminLTE/login.ctp
@@ -47,7 +47,7 @@ $skinName = Configure::read('Theme.skin');
         ?>
         <div class="login-box">
             <div class="login-logo">
-                <a href="<?php echo $this->Url->build('/'); ?>"><?php echo $theme['logo']['large'] ?></a>
+                <a href="<?php echo $this->Url->build('/'); ?>"><?= $this->element('logo') ?></a>
             </div>
             <!-- /.login-logo -->
             <div class="login-box-body">

--- a/src/Template/Layout/adminlte.ctp
+++ b/src/Template/Layout/adminlte.ctp
@@ -35,9 +35,9 @@ $skinName = Configure::read('Theme.skin');
                 <!-- Logo -->
                 <a href="<?php echo $this->Url->build('/'); ?>" class="logo">
                     <!-- mini logo for sidebar mini 50x50 pixels -->
-                    <span class="logo-mini"><?php echo Configure::read('Theme.logo.mini'); ?></span>
+                    <span class="logo-mini"><?= $this->element('logo', ['size' => 'mini']) ?></span>
                     <!-- logo for regular state and mobile devices -->
-                    <span class="logo-lg"><?php echo Configure::read('Theme.logo.large'); ?></span>
+                    <span class="logo-lg"><?= $this->element('logo') ?></span>
                 </a>
                 <!-- Header Navbar: style can be found in header.less -->
                 <?php echo $this->element('nav-top') ?>

--- a/src/Template/Layout/error.ctp
+++ b/src/Template/Layout/error.ctp
@@ -54,10 +54,10 @@ $skinName = Configure::read('Theme.skin');
         <header class="main-header">
             <!-- Logo -->
             <a href="<?php echo $this->Url->build('/'); ?>" class="logo">
-              <!-- mini logo for sidebar mini 50x50 pixels -->
-              <span class="logo-mini"><?= $this->element('logo', ['size' => 'mini']) ?></span>
-              <!-- logo for regular state and mobile devices -->
-              <span class="logo-lg"><?= $this->element('logo') ?></span>
+                <!-- mini logo for sidebar mini 50x50 pixels -->
+                <span class="logo-mini"><?= $this->element('logo', ['size' => 'mini']) ?></span>
+                <!-- logo for regular state and mobile devices -->
+                <span class="logo-lg"><?= $this->element('logo') ?></span>
             </a>
             <!-- Header Navbar: style can be found in header.less -->
             <?php echo $this->element('nav-top') ?>

--- a/src/Template/Layout/error.ctp
+++ b/src/Template/Layout/error.ctp
@@ -54,10 +54,10 @@ $skinName = Configure::read('Theme.skin');
         <header class="main-header">
             <!-- Logo -->
             <a href="<?php echo $this->Url->build('/'); ?>" class="logo">
-                <!-- mini logo for sidebar mini 50x50 pixels -->
-                <span class="logo-mini"><?php echo Configure::read('Theme.logo.mini'); ?></span>
-                <!-- logo for regular state and mobile devices -->
-                <span class="logo-lg"><?php echo Configure::read('Theme.logo.large'); ?></span>
+              <!-- mini logo for sidebar mini 50x50 pixels -->
+              <span class="logo-mini"><?= $this->element('logo', ['size' => 'mini']) ?></span>
+              <!-- logo for regular state and mobile devices -->
+              <span class="logo-lg"><?= $this->element('logo') ?></span>
             </a>
             <!-- Header Navbar: style can be found in header.less -->
             <?php echo $this->element('nav-top') ?>


### PR DESCRIPTION
Removes the support for HTML / img tags from configuration files and moves it into the logo element.