### PR TITLE
Enable LookupBehavior for all Models (task #11230)

### DIFF
--- a/src/Model/Table/AppTable.php
+++ b/src/Model/Table/AppTable.php
@@ -39,9 +39,7 @@ class AppTable extends Table
             ]);
         }
 
-        if (Hash::get($tableConfig, 'table.lookup_fields')) {
-            $this->addBehavior('Lookup', ['lookupFields' => $tableConfig['table']['lookup_fields']]);
-        }
+        $this->addBehavior('Lookup', ['lookupFields' => $tableConfig['table']['lookup_fields']]);
     }
 
     /**


### PR DESCRIPTION
Due some issues on modules that does not have the lookup fields but, they are related to a module which has it, we enable the LookupBehavior for every models.