### PR TITLE
Add email in views to avoid double empty records

### DIFF
--- a/config/Modules/Things/views/add.dist.json
+++ b/config/Modules/Things/views/add.dist.json
@@ -10,6 +10,11 @@
             "Things",
             "testmetric",
             "testmoney"
+        ],
+        [
+            "Things",
+            "email",
+            ""
         ]
     ]
 }

--- a/config/Modules/Things/views/edit.dist.json
+++ b/config/Modules/Things/views/edit.dist.json
@@ -10,6 +10,11 @@
             "Things",
             "testmetric",
             "testmoney"
+        ],
+        [
+            "Things",
+            "email",
+            ""
         ]
     ]
 }

--- a/config/Modules/Things/views/view.dist.json
+++ b/config/Modules/Things/views/view.dist.json
@@ -13,6 +13,11 @@
         ],
         [
             "Things",
+            "email",
+            ""
+        ],
+        [
+            "Things",
             "created",
             "modified"
         ]


### PR DESCRIPTION
Since the `email` field is unique in the database, if is not present in the views, the value will be always empty and it will not possible to save more than one record.