### PR TITLE
Execute only if batch action is detected (task #12349)

### DIFF
--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -97,11 +97,11 @@ class CsvViewComponent extends Component
                 $controller->viewVars['fields'],
                 array_flip($panels['fail'])
             );
-
-            return;
         }
 
-        $this->filterBatchFields($event);
+        if ($batchAction) {
+            $this->filterBatchFields($event);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes the issue with some detailed view fields being stripped-out because batch fields filter logic was executing regardless of the current controller action being the _batch_ or not.