### PR TITLE
Extending integration tests (task #12640)

### DIFF
--- a/src/Event/Controller/Api/LookupActionListener.php
+++ b/src/Event/Controller/Api/LookupActionListener.php
@@ -88,21 +88,23 @@ class LookupActionListener extends BaseActionListener
             return;
         }
 
-        // add typeahead fields to where clause
+        $conditions = [];
         foreach ($fields as $field) {
             $csvField = $this->_getCsvField($field, $table);
             if (!empty($csvField) && 'related' === $csvField->getType()) {
                 $values = $this->_getRelatedModuleValues($csvField, $request);
-                $query->orWhere([$field . ' IN' => $values]);
+                $conditions[$field . ' IN'] = $values;
             } else {
                 // always type-cast fields to string for LIKE clause to work.
                 // otherwise for cases where type is integer LIKE value '%123%' will be converted to '0'
                 $typeMap = array_combine($fields, array_pad([], count($fields), 'string'));
                 Assert::isArray($typeMap);
                 $query->setTypeMap($typeMap);
-                $query->orWhere([$field . ' LIKE' => '%' . $value . '%']);
+                $conditions[$field . ' LIKE'] = '%' . $value . '%';
             }
         }
+
+        $query->where(['OR' => $conditions]);
     }
 
     /**

--- a/tests/TestCase/Controller/BaseModuleControllerTest.php
+++ b/tests/TestCase/Controller/BaseModuleControllerTest.php
@@ -1,0 +1,173 @@
+<?php
+namespace App\Test\TestCase\Controller;
+
+use App\Feature\Factory;
+use Cake\Core\App;
+use Cake\Core\Configure;
+use Cake\Filesystem\Folder;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestCase;
+use Cake\Utility\Inflector;
+use Qobo\Utils\ModuleConfig\ConfigType;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
+use Webmozart\Assert\Assert;
+
+class BaseModuleControllerTest extends IntegrationTestCase
+{
+    public $fixtures = [
+        'plugin.CsvMigrations.dblists',
+        'plugin.CsvMigrations.dblist_items',
+        'plugin.Menu.menus',
+        'plugin.Menu.menu_items',
+        'plugin.Search.saved_searches',
+        'app.file_storage',
+        'app.log_audit',
+        'app.things',
+        'app.users',
+    ];
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->disableErrorHandlerMiddleware();
+
+        $this->session([
+            'Auth' => [
+                'User' => TableRegistry::get('Users')->get('00000000-0000-0000-0000-000000000002')->toArray()
+            ]
+        ]);
+    }
+
+    /**
+     * @dataProvider modulesProvider
+     */
+    public function testIndex(string $module) : void
+    {
+        $this->get('/' . Inflector::dasherize($module));
+
+        $this->assertResponseOk();
+        $this->assertContentType('text/html');
+        $this->assertResponseContains('<table-ajax');
+    }
+
+    /**
+     * @dataProvider modulesProvider
+     */
+    public function testView(string $module) : void
+    {
+        $table = TableRegistry::getTableLocator()->get($module);
+        $entity = $table->find()->firstOrFail();
+
+        $primaryKey = $table->getPrimaryKey();
+        Assert::string($primaryKey);
+
+        $this->get('/' . Inflector::dasherize($module) . '/view/' . $entity->get($primaryKey));
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('text/html');
+        $this->assertResponseContains(sprintf('<h4><a href="/%s">', Inflector::dasherize($module)));
+    }
+
+    /**
+     * @dataProvider modulesProvider
+     */
+    public function testAddGetRequest(string $module) : void
+    {
+        $table = TableRegistry::getTableLocator()->get($module);
+
+        $this->get('/' . Inflector::dasherize($module) . '/add/');
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('text/html');
+        $this->assertResponseContains(sprintf('<h4><a href="/%s">', Inflector::dasherize($module)));
+    }
+
+    /**
+     * @dataProvider modulesProvider
+     */
+    public function testEditGetRequest(string $module) : void
+    {
+        $table = TableRegistry::getTableLocator()->get($module);
+        $entity = $table->find()->firstOrFail();
+
+        $primaryKey = $table->getPrimaryKey();
+        Assert::string($primaryKey);
+
+        $this->get('/' . Inflector::dasherize($module) . '/edit/' . $entity->get($primaryKey));
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('text/html');
+        $this->assertResponseContains(sprintf('<h4><a href="/%s">', Inflector::dasherize($module)));
+    }
+
+    /**
+     * @dataProvider modulesProvider
+     */
+    public function testDelete(string $module) : void
+    {
+        $this->enableCsrfToken();
+        $this->enableSecurityToken();
+
+        $table = TableRegistry::getTableLocator()->get($module);
+        $entity = $table->find()->firstOrFail();
+
+        $primaryKey = $table->getPrimaryKey();
+        Assert::string($primaryKey);
+
+        $this->delete('/' . Inflector::dasherize($module) . '/delete/' . $entity->get($primaryKey));
+
+        $this->assertRedirect();
+        $this->assertContentType('text/html');
+
+        $query = $table->find()->where([$primaryKey => $entity->get($primaryKey)]);
+        $this->assertTrue($query->isEmpty());
+    }
+
+    /**
+     * Modules provider.
+     *
+     * @return mixed[]
+     */
+    public function modulesProvider() : array
+    {
+        // return [['Accounts']];
+        // store default path
+        $defaultPath = Configure::read('CsvMigrations.modules.path');
+
+        Configure::write('CsvMigrations.modules.path', CONFIG . 'Modules' . DS);
+
+        $modules = [];
+        foreach ((new Folder(App::path('Controller')[0]))->find('^\w+Controller\.php$') as $file) {
+            array_push($modules, basename($file, 'Controller.php'));
+        }
+
+        $modules = array_filter($modules, [$this, 'isModule']);
+        $modules = array_filter($modules, [$this, 'isActive']);
+
+        // restore default path
+        Configure::write('CsvMigrations.modules.path', $defaultPath);
+
+        return array_map(function ($module) {
+            return [$module];
+        }, $modules);
+    }
+
+    private function isModule(string $name) : bool
+    {
+        if (in_array($name, ['DynamicTemplateMessages', 'ScheduledJobLogs'], true)) {
+            return false;
+        }
+
+        $config = (new ModuleConfig(ConfigType::MIGRATION(), $name, '', ['cacheSkip' => true]))->parseToArray();
+
+        return [] !== $config;
+    }
+
+    private function isActive(string $module) : bool
+    {
+        $feature = Factory::get('Module' . DS . $module);
+
+        return $feature->isActive();
+    }
+}

--- a/tests/TestCase/Controller/BaseModuleControllerTest.php
+++ b/tests/TestCase/Controller/BaseModuleControllerTest.php
@@ -58,6 +58,7 @@ class BaseModuleControllerTest extends IntegrationTestCase
     {
         $table = TableRegistry::getTableLocator()->get($module);
         $entity = $table->find()->firstOrFail();
+        Assert::isInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
 
         $primaryKey = $table->getPrimaryKey();
         Assert::string($primaryKey);
@@ -90,6 +91,7 @@ class BaseModuleControllerTest extends IntegrationTestCase
     {
         $table = TableRegistry::getTableLocator()->get($module);
         $entity = $table->find()->firstOrFail();
+        Assert::isInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
 
         $primaryKey = $table->getPrimaryKey();
         Assert::string($primaryKey);
@@ -111,6 +113,7 @@ class BaseModuleControllerTest extends IntegrationTestCase
 
         $table = TableRegistry::getTableLocator()->get($module);
         $entity = $table->find()->firstOrFail();
+        Assert::isInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
 
         $primaryKey = $table->getPrimaryKey();
         Assert::string($primaryKey);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,7 @@ require dirname(__DIR__) . '/config/bootstrap.php';
 $_SERVER['PHP_SELF'] = '/';
 
 restore_error_handler();
+// re-enable deprecation errors to be shown on the CLI during PHPunit execution.
 Configure::write('Error.errorLevel', E_ALL);
 // re-register application error and exception handlers.
 (new ConsoleErrorHandler(Configure::read('Error')))->register();


### PR DESCRIPTION
This PR introduces integration tests for all module controllers. The approach is very similar to our existing API controllers integration [tests](https://github.com/QoboLtd/project-template-cakephp/blob/v47.1.1/tests/TestCase/Controller/Api/ControllerApiTest.php). For now, we are checking _GET_ requests (except _delete_ action), asserting the appropriate response code and some basic body-contains assertions.