### PR TITLE
Add dropdown menu "More Actions" in modules view (task #12342)

### DIFF
--- a/src/Event/Plugin/Menu/View/ModuleViewListener.php
+++ b/src/Event/Plugin/Menu/View/ModuleViewListener.php
@@ -12,6 +12,7 @@ use Menu\Event\EventName as MenuEventName;
 use Menu\MenuBuilder\MenuInterface;
 use Menu\MenuBuilder\MenuItemFactory;
 use Menu\MenuBuilder\MenuItemInterface;
+use Webmozart\Assert\Assert;
 
 class ModuleViewListener implements EventListenerInterface
 {
@@ -43,6 +44,8 @@ class ModuleViewListener implements EventListenerInterface
      */
     public function getMenuItems(Event $event, string $name, array $user, bool $fullBaseUrl = false, array $modules = [], MenuInterface $menu = null): void
     {
+        Assert::isInstanceOf($menu, MenuInterface::class);
+
         $listens = [MenuName::MODULE_VIEW];
         if (!in_array($name, $listens)) {
             return;
@@ -58,15 +61,22 @@ class ModuleViewListener implements EventListenerInterface
          * @var \Cake\Http\ServerRequest $request
          */
         $request = Router::getRequest();
-        /**
-         * @var \Menu\MenuBuilder\MenuInterface $menu
-         */
-        $menu = $menu;
-        $menu->addMenuItem($this->getPermissionsMenuItem($entity, $request));
-        $menu->addMenuItem($this->getChangelogMenuItem($entity, $request));
+        Assert::isInstanceOf($request, ServerRequest::class);
+
         $menu->addMenuItem($this->getEditMenuItem($entity, $request));
         $menu->addMenuItem($this->getDeleteMenuItem($entity, $request));
 
+        $moreActions = MenuItemFactory::createMenuItem([
+            'label' => __('More Actions'),
+            'icon' => 'plus-square-o',
+            'type' => 'button_group',
+            'order' => 0,
+        ]);
+
+        $moreActions->addMenuItem($this->getPermissionsMenuItem($entity, $request));
+        $moreActions->addMenuItem($this->getChangelogMenuItem($entity, $request));
+
+        $menu->addMenuItem($moreActions);
         $event->setResult($event);
     }
 
@@ -85,6 +95,7 @@ class ModuleViewListener implements EventListenerInterface
 
         return MenuItemFactory::createMenuItem([
             'url' => ['plugin' => $plugin, 'controller' => $controller, 'action' => 'managePermissions'],
+            'attributes' => ['class' => ' '],
             'label' => __('Permissions'),
             'icon' => 'shield',
             'type' => 'link_button_modal',
@@ -109,6 +120,7 @@ class ModuleViewListener implements EventListenerInterface
 
         return MenuItemFactory::createMenuItem([
             'url' => ['plugin' => $plugin, 'controller' => $controller, 'action' => 'changelog', $id],
+            'attributes' => ['class' => ' '],
             'label' => __('Changelog'),
             'icon' => 'book',
             'type' => 'link_button',

--- a/src/Template/Element/modal-permissions.ctp
+++ b/src/Template/Element/modal-permissions.ctp
@@ -47,6 +47,16 @@ foreach (PermissionsTable::ALLOWED_ACTIONS as $action) {
     $controllerPermissions[$action] = Inflector::humanize($action);
 }
 ?>
+
+<?php $this->Html->scriptStart(['block' => 'scriptBottom']); ?>
+    (function ($) {
+        $(document).ready(function () {
+            let parent = $('#permissions-modal-add').closest('.btn-group');
+            $('#permissions-modal-add').detach().appendTo(parent);
+        });
+    })(jQuery);
+<?= $this->Html->scriptEnd() ?>
+
 <div class="modal fade" id="permissions-modal-add" tabindex="-1" role="dialog" aria-labelledby="mySetsLabel">
     <div class="modal-dialog" role="document">
         <div class="modal-content">

--- a/webroot/css/custom.css
+++ b/webroot/css/custom.css
@@ -92,3 +92,16 @@
     margin-top: 24px;
     padding-top: 24px;
 }
+
+/** hr separator on menu dropdown */
+hr.separator {
+    margin: 5px;
+}
+.separatorTitle {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: 600;
+    color: #333;
+    white-space: nowrap;
+}


### PR DESCRIPTION
To avoid have a long queue of buttons on the top view page, we can now decide to attach an action in the new dropdown "More Actions".

Note to remember: if modals are used ( `link_button_modal` ), the html code involved have to be moved in the DOM in an upper level, out of the dropdown, to make it work (see `modal-permissions.ctp`).