### PR TITLE
Search fix (task #13124)

### DIFF
--- a/resources/src/store/modules/search/index.js
+++ b/resources/src/store/modules/search/index.js
@@ -67,7 +67,7 @@ export default {
 
       Vue.set(criteria[filter[0].field], guid, {
         type: filter[0].type,
-        operator: state.operators.types[state.operators.map[filter[0].type]][0].text,
+        operator: payload.operator !== '' ? payload.operator : state.operators.types[state.operators.map[filter[0].type]][0].text,
         value: payload.value !== '' ? payload.value : (filter[0].type === 'boolean' ? 0 : '')
       })
     },

--- a/resources/src/store/modules/search/index.js
+++ b/resources/src/store/modules/search/index.js
@@ -119,7 +119,8 @@ export default {
 
       if (payload.action === 'add') {
         payload.available.map(function (column) {
-          if (displayColumns.indexOf(column) === -1) {
+          const found = state.filters.find(filter => filter.field === column)
+          if (displayColumns.indexOf(column) === -1 && found !== undefined) {
             displayColumns.push(column)
           }
         })

--- a/src/Search/MagicValue.php
+++ b/src/Search/MagicValue.php
@@ -99,6 +99,7 @@ final class MagicValue
     {
         return (new Time('yesterday'))->format('Y-m-d H:i:s');
     }
+
     /**
      * Tomorrow's date magic value getter.
      *

--- a/src/Shell/UsersShell.php
+++ b/src/Shell/UsersShell.php
@@ -13,6 +13,7 @@ class UsersShell extends BaseShell
      * @var \App\Model\Table\UsersTable $Users
      */
     public $Users;
+
     /**
      * Add a new superadmin user
      *

--- a/tests/TestCase/SystemInfo/PhpTest.php
+++ b/tests/TestCase/SystemInfo/PhpTest.php
@@ -78,6 +78,7 @@ class PhpTest extends TestCase
         $result = Php::getUploadMaxFilesize();
         $this->assertTrue(is_int($result), "getUploadMaxFilesize() returned a non-integer result");
     }
+
     public function testGetPostMaxSize(): void
     {
         $result = Php::getPostMaxSize();


### PR DESCRIPTION
This PR introduces a fix for search functionality, covering an edge case where the default search of a module was generated with display columns that are not part of the module.

**Changes:**
- The behavior of the search store has been modified to prevent the addition of a display column which is not found in the filters.
- The `savedSearch` mutation has been removed as it was very unstable and was modifying the _saved search_ state at once without the required checks. Instead, we are calling the responsible mutations individually, passing in the values retrieved by the saved search API.
- The _criteriaCreate_ mutation has been enhanced to accept providing the criteria operator as part of the payload. The fallback logic remains as is.