### PR TITLE
Extended search supported associations (task #12481)

### DIFF
--- a/resources/src/components/Search/Search.vue
+++ b/resources/src/components/Search/Search.vue
@@ -408,11 +408,9 @@ export default {
               this.filtersGroup[item][0].association :
               ''
 
-            if (-1 < ['oneToMany', 'manyToMany'].indexOf(association)) {
-              return
+            if (-1 === ['oneToMany', 'manyToMany'].indexOf(association)) {
+              result.push(item)
             }
-
-            result.push(item)
           })
 
           return result

--- a/resources/src/components/Search/Search.vue
+++ b/resources/src/components/Search/Search.vue
@@ -25,7 +25,7 @@
                                 <div class="col-xs-4">
                                     <div class="form-group">
                                         <select v-model="selectedModuleGroupBy" class="form-control input-sm">
-                                            <option v-for="item in filterModules">{{ item }}</option>
+                                            <option v-for="item in displayModules">{{ item }}</option>
                                         </select>
                                     </div>
                                 </div>
@@ -95,7 +95,7 @@
                                         <option v-for="filter in filtersGroup[selectedModuleAvailableColumns]" v-if="-1 === displayColumns.indexOf(filter.field)" :value="filter.field">{{ filter.label }}</option>
                                     </select>
                                     <select v-model="selectedModuleAvailableColumns" class="form-control input-sm" :disabled="isGroupByEnabled">
-                                        <option v-for="(group_filters, group) in filtersGroup">{{ group }}</option>
+                                        <option v-for="item in displayModules">{{ item }}</option>
                                     </select>
                                 </div>
                                 <div class="col-md-2">
@@ -391,6 +391,27 @@ export default {
           }
 
           Object.keys(this.filtersGroup).forEach((item) => {
+            result.push(item)
+          })
+
+          return result
+        },
+        displayModules () {
+          let result = []
+
+          if (!this.filtersGroup) {
+            return result
+          }
+
+          Object.keys(this.filtersGroup).forEach((item) => {
+            const association = this.filtersGroup[item].hasOwnProperty(0) ?
+              this.filtersGroup[item][0].association :
+              ''
+
+            if (-1 < ['oneToMany', 'manyToMany'].indexOf(association)) {
+              return
+            }
+
             result.push(item)
           })
 

--- a/src/Utility/Search.php
+++ b/src/Utility/Search.php
@@ -44,6 +44,12 @@ final class Search
      */
     private static $associationLabels = [];
 
+    const SUPPORTED_ASSOCIATIONS = [
+        Association::MANY_TO_ONE,
+        Association::MANY_TO_MANY,
+        Association::ONE_TO_MANY
+    ];
+
     /**
      * Charts list.
      *
@@ -258,7 +264,7 @@ final class Search
 
         $result = [];
         foreach ($table->associations() as $association) {
-            if (! in_array($association->type(), [Association::MANY_TO_ONE])) {
+            if (! in_array($association->type(), self::SUPPORTED_ASSOCIATIONS)) {
                 continue;
             }
 
@@ -420,7 +426,7 @@ final class Search
 
         foreach ($table->associations() as $association) {
             // skip non-supported associations
-            if (! in_array($association->type(), [Association::MANY_TO_ONE])) {
+            if (! in_array($association->type(), self::SUPPORTED_ASSOCIATIONS)) {
                 continue;
             }
 
@@ -431,11 +437,16 @@ final class Search
                 continue;
             }
 
-            $result = array_merge(
-                $result,
-                // fetch associated model searchable fields
-                self::getSearchableFields($targetTable, false)
-            );
+            // fetch associated model searchable fields
+            $fields = self::getSearchableFields($targetTable, false);
+
+            $fields = array_map(function ($item) use ($association) {
+                $item['association'] = $association->type();
+
+                return $item;
+            }, $fields);
+
+            $result = array_merge($result, $fields);
         }
 
         return $result;

--- a/src/Utility/Search.php
+++ b/src/Utility/Search.php
@@ -126,7 +126,7 @@ final class Search
      */
     public static function getChartOptions(SavedSearch $savedSearch) : array
     {
-        if (null === Hash::get($savedSearch->get('content'), 'saved.group_by')) {
+        if ('' === Hash::get($savedSearch->get('content'), 'saved.group_by', '')) {
             return [];
         }
 

--- a/tests/TestCase/Utility/SearchTest.php
+++ b/tests/TestCase/Utility/SearchTest.php
@@ -2,9 +2,9 @@
 namespace App\Test\TestCase\Utility;
 
 use App\Utility\Search;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Qobo\Utils\Utility\User;
+use Search\Model\Entity\SavedSearch;
 
 class SearchTest extends TestCase
 {
@@ -59,8 +59,7 @@ class SearchTest extends TestCase
 
     public function testGetChartOptions() : void
     {
-        $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
-        $data = [
+        $savedSearch = new SavedSearch([
             'name' => 'Things grouped by created date',
             'model' => 'Things',
             'content' => [
@@ -68,10 +67,9 @@ class SearchTest extends TestCase
                     'group_by' => 'Things.created'
                 ]
             ]
-        ];
-        $entity = $table->newEntity($data);
+        ]);
 
-        $result = Search::getChartOptions($entity);
+        $result = Search::getChartOptions($savedSearch);
 
         $this->assertCount(3, $result);
         $this->assertSame([], array_diff(['pie', 'bar', 'funnelChart'], array_column($result, 'chart')));
@@ -79,18 +77,16 @@ class SearchTest extends TestCase
 
     public function testGetChartOptionsWithoutGroupBy() : void
     {
-        $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
-        $data = [
-            'name' => 'Things grouped by created date',
+        $savedSearch = new SavedSearch([
+            'name' => 'Things NOT grouped by',
             'model' => 'Things',
             'content' => [
                 'saved' => [
                     'group_by' => ''
                 ]
             ]
-        ];
-        $entity = $table->newEntity($data);
+        ]);
 
-        $this->assertSame([], Search::getChartOptions($entity));
+        $this->assertSame([], Search::getChartOptions($savedSearch));
     }
 }

--- a/tests/TestCase/Utility/SearchTest.php
+++ b/tests/TestCase/Utility/SearchTest.php
@@ -1,0 +1,96 @@
+<?php
+namespace App\Test\TestCase\Utility;
+
+use App\Utility\Search;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Qobo\Utils\Utility\User;
+
+class SearchTest extends TestCase
+{
+    public $fixtures = [
+        'plugin.Search.saved_searches'
+    ];
+
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        User::setCurrentUser(['is_superuser' => true]);
+    }
+
+    public function testGetFilters() : void
+    {
+        $result = Search::getFilters('Things');
+
+        $expected = [
+            'type' => 'string',
+            'label' => 'Email',
+            'field' => 'AssignedToUsers.email',
+            'association' => 'manyToOne',
+            'group' => 'Users (Assigned To)'
+        ];
+        $index = array_search($expected['field'], array_column($result, 'field'));
+        $this->assertSame($expected, $result[$index]);
+
+        $expected = [
+            'type' => 'string',
+            'label' => 'label name',
+            'field' => 'Things.name',
+            'group' => 'Things'
+        ];
+        $index = array_search($expected['field'], array_column($result, 'field'));
+        $this->assertSame($expected, $result[$index]);
+    }
+
+    public function testGetDisplayFields() : void
+    {
+        $expected = [
+            'Things.id',
+            'Things.name',
+            'Things.gender',
+            'Things.assigned_to',
+            'Things.created',
+            'Things.modified'
+        ];
+
+        $this->assertSame($expected, Search::getDisplayFields('Things'));
+    }
+
+    public function testGetChartOptions() : void
+    {
+        $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
+        $data = [
+            'name' => 'Things grouped by created date',
+            'model' => 'Things',
+            'content' => [
+                'saved' => [
+                    'group_by' => 'Things.created'
+                ]
+            ]
+        ];
+        $entity = $table->newEntity($data);
+
+        $result = Search::getChartOptions($entity);
+
+        $this->assertCount(3, $result);
+        $this->assertSame([], array_diff(['pie', 'bar', 'funnelChart'], array_column($result, 'chart')));
+    }
+
+    public function testGetChartOptionsWithoutGroupBy() : void
+    {
+        $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
+        $data = [
+            'name' => 'Things grouped by created date',
+            'model' => 'Things',
+            'content' => [
+                'saved' => [
+                    'group_by' => ''
+                ]
+            ]
+        ];
+        $entity = $table->newEntity($data);
+
+        $this->assertSame([], Search::getChartOptions($entity));
+    }
+}


### PR DESCRIPTION
This PR extends search filters by including the columns of `M:M` and `1:M` associations into the list.

**Changes:** 
- Added `M:M` and `1:M` columns in search filters
- Skipped adding `M:M` and `1:M` columns under _display_ and _group by_ columns