### PR TITLE
Fix the issue with the format pretty in combinedFields (Task #3984)

### DIFF
--- a/tests/Fixture/ThingsFixture.php
+++ b/tests/Fixture/ThingsFixture.php
@@ -34,6 +34,10 @@ class ThingsFixture extends TestFixture
             'modified' => '2018-01-18 15:47:16',
             'created_by' => '00000000-0000-0000-0000-000000000001',
             'modified_by' => '00000000-0000-0000-0000-000000000001',
+            'area_amount' => '25',
+            'area_unit' => 'm',
+            'salary_amount' => '1000',
+            'salary_currency' => 'EUR',
             'trashed' => null
         ],
         [

--- a/tests/TestCase/Controller/Api/ControllerApiTest.php
+++ b/tests/TestCase/Controller/Api/ControllerApiTest.php
@@ -2,10 +2,12 @@
 namespace App\Test\TestCase\Controller\Api;
 
 use App\Crud\Action\SchemaAction;
+use App\Event\Controller\Api\IndexActionListener;
 use App\Feature\Factory;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Event\EventManager;
 use Cake\Filesystem\Folder;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -24,13 +26,16 @@ class ControllerApiTest extends JsonIntegrationTestCase
         'plugin.CsvMigrations.dblist_items',
         'app.things',
         'app.log_audit',
-        'app.users'
+        'app.users',
+        'app.file_storage'
     ];
 
     public function setUp()
     {
         parent::setUp();
+
         $this->setRequestHeaders([], '00000000-0000-0000-0000-000000000002');
+        EventManager::instance()->on(new IndexActionListener());
     }
 
     public function testApiFilesPlacedCorrectly(): void
@@ -45,6 +50,42 @@ class ControllerApiTest extends JsonIntegrationTestCase
         }
 
         $this->assertEquals(0, $found, "Check API directory. Not all controllers were moved to corresponding API subdirs");
+    }
+
+    /**
+     * @dataProvider modulesProvider
+     */
+    public function testFormatPrettyAmount(string $module): void
+    {
+        $this->get('/api/' . Inflector::dasherize($module) . '?format=pretty');
+        $response = $this->getParsedResponse();
+        $data = $response->data[1];
+        $this->assertEquals($data->area_amount, '25.00');
+        $this->assertJsonResponseOk();
+    }
+
+    /**
+     * @dataProvider modulesProvider
+     */
+    public function testFormatPrettyUnit(string $module): void
+    {
+        $this->get('/api/' . Inflector::dasherize($module) . '?format=pretty');
+        $response = $this->getParsedResponse();
+        $data = $response->data[1];
+        $this->assertEquals($data->area_unit, 'm²');
+        $this->assertJsonResponseOk();
+    }
+
+    /**
+     * @dataProvider modulesProvider
+     */
+    public function testFormatPrettyCurrency(string $module): void
+    {
+        $this->get('/api/' . Inflector::dasherize($module) . '?format=pretty');
+        $response = $this->getParsedResponse();
+        $data = $response->data[1];
+        $this->assertEquals($data->salary_currency, '<span title="Euro">€&nbsp;(EUR)</span>');
+        $this->assertJsonResponseOk();
     }
 
     /**


### PR DESCRIPTION
This PR fixes the response that is coming when using `format=pretty` for example if the units are `m` will convert them to `m²` 