### PR TITLE
Fix type in settings (task #13393)

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -22,7 +22,7 @@ return [
                 'General' => [
                     'Transport' => [
                         'alias' => 'EmailTransport.default.className',
-                        'type' => 'string',
+                        'type' => 'list',
                         'selectOptions' => [
                             'mail' => 'Mail',
                             'smtp' => 'Smtp',


### PR DESCRIPTION
To show the select dropdown, the type have to be `list`, not `string`