### PR TITLE
Fix a bug that the App pane is visible only when initializing the page (Task #11433, Task #13269)

### DIFF
--- a/resources/src/components/Dashboard/DashboardGrid.vue
+++ b/resources/src/components/Dashboard/DashboardGrid.vue
@@ -42,13 +42,13 @@
         <div class="col-md-2">
           <ul class="nav nav-tabs nav-stacked">
             <li v-for="type in widgetTypes" v-bind:class="getActiveTab(type, widgetTypes[0], '')" class="widget-tab">
-              <a :href="'#' + type" data-toggle="tab">{{camelize(type)}}</a>
+              <a :href="'#' + type + '_tab'" data-toggle="tab">{{camelize(type)}}</a>
             </li>
           </ul>
         </div>
         <div class="col-md-10">
           <div class="tab-content">
-            <div role="tabpanel" v-bind:class="getActiveTab(type, widgetTypes[0], 'tab-pane')" v-for="type in widgetTypes" :id="type">
+            <div role="tabpanel" v-bind:class="getActiveTab(type, widgetTypes[0], 'tab-pane')" v-for="type in widgetTypes" :id="type + '_tab'">
               <div class="box-body">
                 <ul class="nav nav-tabs" v-if="type == 'saved_search'">
                   <li v-for="model in searchModules" v-bind:class="getActiveTab(model, searchModules[0], '')">


### PR DESCRIPTION
This PR fixes the issue that the App pane is visible only when initializing the page. It seems that we have a duplicate id="app" and the class "active" goes on the first element. 