### PR TITLE
 Move specific tests for Things into ThingsController (task #13724)

### DIFF
--- a/tests/TestCase/Controller/Api/ControllerApiTest.php
+++ b/tests/TestCase/Controller/Api/ControllerApiTest.php
@@ -55,42 +55,6 @@ class ControllerApiTest extends JsonIntegrationTestCase
     /**
      * @dataProvider modulesProvider
      */
-    public function testFormatPrettyAmount(string $module): void
-    {
-        $this->get('/api/' . Inflector::dasherize($module) . '?format=pretty');
-        $response = $this->getParsedResponse();
-        $data = $response->data[1];
-        $this->assertEquals($data->area_amount, '25.00');
-        $this->assertJsonResponseOk();
-    }
-
-    /**
-     * @dataProvider modulesProvider
-     */
-    public function testFormatPrettyUnit(string $module): void
-    {
-        $this->get('/api/' . Inflector::dasherize($module) . '?format=pretty');
-        $response = $this->getParsedResponse();
-        $data = $response->data[1];
-        $this->assertEquals($data->area_unit, 'm²');
-        $this->assertJsonResponseOk();
-    }
-
-    /**
-     * @dataProvider modulesProvider
-     */
-    public function testFormatPrettyCurrency(string $module): void
-    {
-        $this->get('/api/' . Inflector::dasherize($module) . '?format=pretty');
-        $response = $this->getParsedResponse();
-        $data = $response->data[1];
-        $this->assertEquals($data->salary_currency, '<span title="Euro">€&nbsp;(EUR)</span>');
-        $this->assertJsonResponseOk();
-    }
-
-    /**
-     * @dataProvider modulesProvider
-     */
     public function testIndex(string $module): void
     {
         $this->get('/api/' . Inflector::dasherize($module));

--- a/tests/TestCase/Controller/Api/ControllerApiTest.php
+++ b/tests/TestCase/Controller/Api/ControllerApiTest.php
@@ -2,12 +2,10 @@
 namespace App\Test\TestCase\Controller\Api;
 
 use App\Crud\Action\SchemaAction;
-use App\Event\Controller\Api\IndexActionListener;
 use App\Feature\Factory;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Event\EventManager;
 use Cake\Filesystem\Folder;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -35,7 +33,6 @@ class ControllerApiTest extends JsonIntegrationTestCase
         parent::setUp();
 
         $this->setRequestHeaders([], '00000000-0000-0000-0000-000000000002');
-        EventManager::instance()->on(new IndexActionListener());
     }
 
     public function testApiFilesPlacedCorrectly(): void

--- a/tests/TestCase/Controller/Api/V1/V0/ThingsControllerTest.php
+++ b/tests/TestCase/Controller/Api/V1/V0/ThingsControllerTest.php
@@ -2,14 +2,19 @@
 
 namespace App\Test\TestCase\Controller\Api\V1\V0;
 
+use App\Event\Controller\Api\IndexActionListener;
 use App\Feature\Factory;
+use Cake\Event\EventManager;
 use Cake\Utility\Inflector;
 use Qobo\Utils\TestSuite\JsonIntegrationTestCase;
 
 class ThingsControllerTest extends JsonIntegrationTestCase
 {
     public $fixtures = [
-        'app.things'
+        'app.things',
+        'app.log_audit',
+        'app.users',
+        'app.file_storage'
     ];
 
     private $moduleName = 'Things';
@@ -25,6 +30,7 @@ class ThingsControllerTest extends JsonIntegrationTestCase
         parent::setUp();
 
         $this->setRequestHeaders([], '00000000-0000-0000-0000-000000000002');
+        EventManager::instance()->on(new IndexActionListener());
     }
 
     public function testFormatPrettyAmount(): void
@@ -32,7 +38,7 @@ class ThingsControllerTest extends JsonIntegrationTestCase
         $this->get('/api/' . Inflector::dasherize($this->moduleName) . '/?format=pretty');
         $response = $this->getParsedResponse();
         $data = $response->data[1];
-        $this->assertEquals($data->area_amount, '25.00');
+        $this->assertEquals('25.00', $data->area_amount);
         $this->assertJsonResponseOk();
     }
 
@@ -41,7 +47,7 @@ class ThingsControllerTest extends JsonIntegrationTestCase
         $this->get('/api/' . Inflector::dasherize($this->moduleName) . '?format=pretty');
         $response = $this->getParsedResponse();
         $data = $response->data[1];
-        $this->assertEquals($data->area_unit, 'm²');
+        $this->assertEquals('m²', $data->area_unit);
         $this->assertJsonResponseOk();
     }
 
@@ -50,7 +56,7 @@ class ThingsControllerTest extends JsonIntegrationTestCase
         $this->get('/api/' . Inflector::dasherize($this->moduleName) . '?format=pretty');
         $response = $this->getParsedResponse();
         $data = $response->data[1];
-        $this->assertEquals($data->salary_currency, '<span title="Euro">€&nbsp;(EUR)</span>');
+        $this->assertEquals('<span title="Euro">€&nbsp;(EUR)</span>', $data->salary_currency);
         $this->assertJsonResponseOk();
     }
 }

--- a/tests/TestCase/Controller/Api/V1/V0/ThingsControllerTest.php
+++ b/tests/TestCase/Controller/Api/V1/V0/ThingsControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Test\TestCase\Controller\Api\V1\V0;
+
+use App\Feature\Factory;
+use Cake\Utility\Inflector;
+use Qobo\Utils\TestSuite\JsonIntegrationTestCase;
+
+class ThingsControllerTest extends JsonIntegrationTestCase
+{
+    public $fixtures = [
+        'app.things'
+    ];
+
+    private $moduleName = 'Things';
+
+    public function setUp(): void
+    {
+        $feature = Factory::get('Module' . DS . 'Things');
+
+        if (! $feature->isActive()) {
+            $this->markTestSkipped('Skipping, Things module is disabled');
+        }
+
+        parent::setUp();
+
+        $this->setRequestHeaders([], '00000000-0000-0000-0000-000000000002');
+    }
+
+    public function testFormatPrettyAmount(): void
+    {
+        $this->get('/api/' . Inflector::dasherize($this->moduleName) . '/?format=pretty');
+        $response = $this->getParsedResponse();
+        $data = $response->data[1];
+        $this->assertEquals($data->area_amount, '25.00');
+        $this->assertJsonResponseOk();
+    }
+
+    public function testFormatPrettyUnit(): void
+    {
+        $this->get('/api/' . Inflector::dasherize($this->moduleName) . '?format=pretty');
+        $response = $this->getParsedResponse();
+        $data = $response->data[1];
+        $this->assertEquals($data->area_unit, 'm²');
+        $this->assertJsonResponseOk();
+    }
+
+    public function testFormatPrettyCurrency(): void
+    {
+        $this->get('/api/' . Inflector::dasherize($this->moduleName) . '?format=pretty');
+        $response = $this->getParsedResponse();
+        $data = $response->data[1];
+        $this->assertEquals($data->salary_currency, '<span title="Euro">€&nbsp;(EUR)</span>');
+        $this->assertJsonResponseOk();
+    }
+}


### PR DESCRIPTION
Things specific test methods are being moted to ThingsController. This is a fix for v47.5.x .

One more PR will follow to remove the hardcoded dependencies on fixtures. 