### PR TITLE
Assets Caching (task #13135)

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -129,7 +129,7 @@ return [
      * enable timestamping regardless of debug value.
      */
     'Asset' => [
-        //'timestamp' => true,
+        'timestamp' => 'force',
     ],
 
     /**

--- a/etc/nginx.conf.template
+++ b/etc/nginx.conf.template
@@ -22,16 +22,6 @@ server {
 	error_page 504 /errors/5xx.html; # Gateway Timeout
 
 	#
-	# Expires
-	#
-
-	# Non-aggressive Expires header for JavaScript, CSS, and images
-	#location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-	#	expires 5m;
-	#	log_not_found off;
-	#}
-
-	#
 	# Restrictions
 	#
 

--- a/etc/nginx.ssl.conf.template
+++ b/etc/nginx.ssl.conf.template
@@ -48,16 +48,6 @@ server {
 	error_page 504 /errors/5xx.html; # Gateway Timeout
 
 	#
-	# Expires
-	#
-
-	# Non-aggressive Expires header for JavaScript, CSS, and images
-	#location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-	#	expires 5m;
-	#	log_not_found off;
-	#}
-
-	#
 	# Restrictions
 	#
 


### PR DESCRIPTION
This PR removes `Expires` header as part of the NGINX configuration template which was already disabled. It also forces timestamp on assets i.e. `?1545690197` to avoid caching issues upon deployment to production. 