### PR TITLE
Saved searches bugfix (task #14811)

### DIFF
--- a/config/Migrations/20200107123442_SavedSearchesOrderField.php
+++ b/config/Migrations/20200107123442_SavedSearchesOrderField.php
@@ -1,0 +1,24 @@
+<?php
+use Cake\ORM\TableRegistry;
+use Migrations\AbstractMigration;
+
+class SavedSearchesOrderField extends AbstractMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function up() : void
+    {
+        $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
+
+        foreach ($table->find()->all() as $savedSearch) {
+            if (in_array($savedSearch->get('order_by_field'), $savedSearch->get('fields'), true)) {
+                continue;
+            }
+
+            $savedSearch->set('order_by_field', end($savedSearch->get('fields')));
+
+            $table->saveOrFail($savedSearch);
+        }
+    }
+}

--- a/config/Migrations/20200107123442_SavedSearchesOrderField.php
+++ b/config/Migrations/20200107123442_SavedSearchesOrderField.php
@@ -7,7 +7,7 @@ class SavedSearchesOrderField extends AbstractMigration
     /**
      * {@inheritDoc}
      */
-    public function up() : void
+    public function up(): void
     {
         $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
 

--- a/resources/src/store/modules/search/index.js
+++ b/resources/src/store/modules/search/index.js
@@ -234,14 +234,15 @@ export default {
           commit('orderByDirection', data.order_by_direction)
           if (data.hasOwnProperty('criteria') && typeof data.criteria === 'object' && data.criteria !== null) {
             Object.keys(data.criteria).forEach((item) => {
-              const guid = Object.keys(data.criteria[item])[0]
-              const filter = data.criteria[item][guid]
-              commit('criteriaCreate', {
-                field: item,
-                value: filter.value,
-                operator: filter.operator,
-                guid: guid,
-                type: filter.type
+              Object.keys(data.criteria[item]).forEach((guid) => {
+                const filter = data.criteria[item][guid]
+                commit('criteriaCreate', {
+                  field: item,
+                  value: filter.value,
+                  operator: filter.operator,
+                  guid: guid,
+                  type: filter.type
+                })
               })
             })
           }


### PR DESCRIPTION
This PR resolves the issue when a search that uses two filters for the same field is saved and reloaded, only one of the filters is rendered in the UI.