### PR TITLE
Settings cache (task #15055)

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -141,6 +141,13 @@ return [
             'path' => CACHE,
             'url' => env('CACHE_DEFAULT_URL', null),
         ],
+        'settings' => [
+            'className' => 'File',
+            'prefix' => 'myapp_settings',
+            'path' => CACHE,
+            'serialize' => true,
+            'duration' => '+1 years',
+        ],
 
         /**
          * Configure the cache used for general framework caching.

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -129,6 +129,7 @@ if (Configure::read('debug')) {
 
     Configure::write('Cache._cake_swagger_.duration', '+2 seconds');
     Configure::write('Cache.default.duration', '+2 seconds');
+    Configure::write('Cache.settings.duration', '+2 seconds');
 }
 
 /*

--- a/src/Event/Component/SettingsListener.php
+++ b/src/Event/Component/SettingsListener.php
@@ -30,7 +30,7 @@ class SettingsListener implements EventListenerInterface
      * @param string|null $userId User ID
      * @return void
      */
-    public function loadUserSettings(Event $event, ?string $userId): void
+    public function loadUserSettings(Event $event, ?string $userId = null): void
     {
         $feature = FeatureFactory::get('Module' . DS . 'Settings');
         if (!$feature->isActive()) {

--- a/src/Event/Component/SettingsListener.php
+++ b/src/Event/Component/SettingsListener.php
@@ -4,10 +4,12 @@ namespace App\Event\Component;
 
 use App\Feature\Factory as FeatureFactory;
 use App\Settings\DbConfig;
+use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\ORM\TableRegistry;
+use Webmozart\Assert\Assert;
 
 class SettingsListener implements EventListenerInterface
 {
@@ -25,30 +27,55 @@ class SettingsListener implements EventListenerInterface
      * Load User settings and overwrite defaults
      *
      * @param \Cake\Event\Event $event Event instance
+     * @param string|null $userId User ID
      * @return void
      */
-    public function loadUserSettings(Event $event): void
+    public function loadUserSettings(Event $event, ?string $userId): void
     {
         $feature = FeatureFactory::get('Module' . DS . 'Settings');
-
         if (!$feature->isActive()) {
             return;
         }
 
-        /**
-         * @var \App\Controller\SettingsController
-         */
-        $controller = $event->getSubject();
-        if (! $controller->components()->has('Auth')) {
+        if (!empty($userId)) {
+            $this->loadUserDbConfig($userId);
+
             return;
         }
 
-        $userId = $controller->Auth->user('id');
-
+        $subject = $event->getSubject();
+        Assert::isInstanceOf($subject, Controller::class);
+        $userId = $this->getUserFromController($subject);
         if (empty($userId)) {
             return;
         }
 
+        $this->loadUserDbConfig($userId);
+    }
+
+    /**
+     * Retrieves and returns the User ID from the provided Controller instance
+     *
+     * @param \Cake\Controller\Controller $controller Controller instance
+     * @return string|null
+     */
+    private function getUserFromController(Controller $controller): ?string
+    {
+        if ($controller->components()->has('Auth')) {
+            return $controller->Auth->user('id');
+        }
+
+        return null;
+    }
+
+    /**
+     * Loads the configuration for the specified User ID
+     *
+     * @param string $userId User ID
+     * @return void
+     */
+    private function loadUserDbConfig(string $userId): void
+    {
         Configure::config('dbconfig', new DbConfig('user', $userId));
         Configure::load('Settings', 'dbconfig', true);
     }

--- a/src/Model/Table/SettingsTable.php
+++ b/src/Model/Table/SettingsTable.php
@@ -262,6 +262,6 @@ class SettingsTable extends Table
      */
     public function afterSave(): void
     {
-        Cache::delete('Settings');
+        Cache::clear(false, 'settings');
     }
 }

--- a/tests/Fixture/SettingsFixture.php
+++ b/tests/Fixture/SettingsFixture.php
@@ -32,5 +32,19 @@ class SettingsFixture extends TestFixture
                 'scope' => 'app',
                 'context' => 'bb697cd7-c869-491d-8696-805b1af8c08f',
             ],
-        ];
+            [
+                'id' => 3,
+                'key' => 'Timezone',
+                'value' => 'UTC',
+                'scope' => 'app',
+                'context' => 'app',
+            ],
+            [
+                'id' => 4,
+                'key' => 'Timezone',
+                'value' => 'EEST',
+                'scope' => 'user',
+                'context' => '00000000-0000-0000-0000-000000000001',
+            ],
+    ];
 }

--- a/tests/TestCase/Event/SettingsListenerTest.php
+++ b/tests/TestCase/Event/SettingsListenerTest.php
@@ -4,6 +4,7 @@ namespace App\Test\TestCase\Event;
 
 use App\Event\Component\SettingsListener;
 use App\Settings\DbConfig;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
@@ -27,6 +28,7 @@ class SettingsListenerTest extends TestCase
 
     public function testUserOverwritesAppSettings() : void
     {
+        Cache::clear(false, 'settings');
         $userId = '00000000-0000-0000-0000-000000000001';
         $listener = new SettingsListener();
 

--- a/tests/TestCase/Event/SettingsListenerTest.php
+++ b/tests/TestCase/Event/SettingsListenerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Test\TestCase\Event;
+
+use App\Event\Component\SettingsListener;
+use App\Settings\DbConfig;
+use Cake\Core\Configure;
+use Cake\Event\Event;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class SettingsListenerTest extends TestCase
+{
+    public $fixtures = [
+        'app.users',
+        'app.settings',
+    ];
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        TableRegistry::getTableLocator()->clear();
+        $config = TableRegistry::getTableLocator()->exists('LogAudit') ? [] : ['className' => 'App\Model\Table\SettingsTable'];
+        TableRegistry::getTableLocator()->get('Settings', $config);
+    }
+
+    public function testUserOverwritesAppSettings() : void
+    {
+        $userId = '00000000-0000-0000-0000-000000000001';
+        $listener = new SettingsListener();
+
+        Configure::config('dbconfig', new DbConfig());
+        Configure::load('Settings', 'dbconfig', true);
+        $this->assertEquals('UTC', Configure::read('Timezone'));
+        $listener->loadUserSettings(new Event('dummy'), $userId);
+        $this->assertEquals('EEST', Configure::read('Timezone'));
+    }
+}

--- a/tests/TestCase/Event/SettingsListenerTest.php
+++ b/tests/TestCase/Event/SettingsListenerTest.php
@@ -26,7 +26,7 @@ class SettingsListenerTest extends TestCase
         TableRegistry::getTableLocator()->get('Settings', $config);
     }
 
-    public function testUserOverwritesAppSettings() : void
+    public function testUserOverwritesAppSettings(): void
     {
         Cache::clear(false, 'settings');
         $userId = '00000000-0000-0000-0000-000000000001';

--- a/tests/TestCase/Settings/DbConfigTest.php
+++ b/tests/TestCase/Settings/DbConfigTest.php
@@ -51,7 +51,7 @@ class DbConfigTest extends TestCase
      */
     public function testGetArray(): void
     {
-        Cache::delete('Settings');
+        Cache::clear(false, 'settings');
 
         $array = $this->configure->read('Settings');
         $this->assertInternalType('array', $array);
@@ -63,7 +63,7 @@ class DbConfigTest extends TestCase
      */
     public function testGetEmptyArray(): void
     {
-        Cache::delete('Settings');
+        Cache::clear(false, 'settings');
 
         $array = $this->configure->read('SettingsWrong');
         $this->assertEquals([], $array);


### PR DESCRIPTION
This PR fixes the bug where the User Settings are being overwritten by App Settings (while it should be the other way around). It also introduces a new, dedicated caching for Settings.