### PR TITLE
Replace SVG URL Loader (task #15059)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,12 +1765,14 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
@@ -10853,6 +10855,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",
@@ -11697,26 +11700,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
-    "svg-url-loader": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/svg-url-loader/-/svg-url-loader-2.3.3.tgz",
-      "integrity": "sha512-dFXrXCrtyEucN6dWdvDGMipbVwPPez4OVVYUpxJwLJ5WuaPLYY9RmpOjUparDNs1+sPEXrsdDGIOCOK8NOy5VQ==",
-      "requires": {
-        "file-loader": "4.0.0",
-        "loader-utils": "1.2.3"
-      },
-      "dependencies": {
-        "file-loader": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.0.0.tgz",
-          "integrity": "sha512-roAbL6IdSGczwfXxhMi6Zq+jD4IfUpL0jWHD7fvmjdOVb7xBfdRUHe4LpBgO23VtVK5AW1OlWZo0p34Jvx3iWg==",
-          "requires": {
-            "loader-utils": "^1.2.2",
-            "schema-utils": "^1.0.0"
-          }
-        }
-      }
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "node-sass": "^4.13.0",
     "rrule": "^2.2.0",
     "sass-loader": "^7.3.1",
-    "svg-url-loader": "^2.3.2",
     "vue": "^2.6.10",
     "vue-grid-layout": "^2.3.7",
     "vue-js-modal": "^1.3.31",

--- a/resources/build/webpack.base.conf.js
+++ b/resources/build/webpack.base.conf.js
@@ -40,8 +40,9 @@ module.exports = {
       },
       {
         test: /\.(svg)$/,
-        loader: 'svg-url-loader',
+        loader: 'file-loader',
         options: {
+          name: '[path][name].[ext]?[hash]'
         }
       },
       {


### PR DESCRIPTION
Replace SVG URL Loader for webpack, with s custom file loader option. The previous approach was causing the SVGs to be embedded as base64 in the dist CSS, causing important increase to the file size.