### PR TITLE
Extend modules views (task #15207)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -34,6 +34,7 @@ use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Cake\Utility\Security;
+use Cake\View\Exception\MissingTemplateException;
 use Firebase\JWT\JWT;
 use Qobo\Utils\ModuleConfig\ConfigType;
 use Qobo\Utils\ModuleConfig\ModuleConfig;
@@ -202,7 +203,12 @@ class AppController extends Controller
         }
 
         $this->set('savedSearch', $savedSearch);
-        $this->render('/Module/index');
+
+        try {
+            $this->render();
+        } catch (MissingTemplateException $e) {
+            $this->render('/Module/index');
+        }
     }
 
     /**

--- a/src/Controller/BaseModuleController.php
+++ b/src/Controller/BaseModuleController.php
@@ -24,6 +24,7 @@ use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validation;
+use Cake\View\Exception\MissingTemplateException;
 use CsvMigrations\Controller\Traits\ImportTrait;
 use CsvMigrations\Event\EventName;
 use CsvMigrations\Exception\UnsupportedPrimaryKeyException;
@@ -82,7 +83,13 @@ class BaseModuleController extends AppController
         $entity = $this->fetchEntity($id);
 
         $this->set('entity', $entity);
-        $this->render('/Module/view');
+
+        try {
+            $this->render();
+        } catch (MissingTemplateException $e) {
+            $this->render('/Module/view');
+        }
+
         $this->set('_serialize', ['entity']);
     }
 
@@ -112,7 +119,13 @@ class BaseModuleController extends AppController
         }
 
         $this->set('entity', $entity);
-        $this->render('/Module/add');
+
+        try {
+            $this->render();
+        } catch (MissingTemplateException $e) {
+            $this->render('/Module/add');
+        }
+
         $this->set('_serialize', ['entity']);
     }
 
@@ -144,7 +157,13 @@ class BaseModuleController extends AppController
         }
 
         $this->set('entity', $entity);
-        $this->render('/Module/edit');
+
+        try {
+            $this->render();
+        } catch (MissingTemplateException $e) {
+            $this->render('/Module/edit');
+        }
+
         $this->set('_serialize', ['entity']);
     }
 

--- a/src/Template/Module/add.ctp
+++ b/src/Template/Module/add.ctp
@@ -29,4 +29,7 @@ $options = [
     'handlerOptions' => ['entity' => $this->request],
     'hasPanels' => property_exists($config, 'panels')
 ];
+
+echo $this->fetch('pre_element');
 echo $this->element('Module/post', ['options' => $options]);
+echo $this->fetch('post_element');

--- a/src/Template/Module/edit.ctp
+++ b/src/Template/Module/edit.ctp
@@ -35,4 +35,7 @@ $options = [
     'handlerOptions' => ['entity' => $entity],
     'hasPanels' => property_exists($config, 'panels')
 ];
+
+echo $this->fetch('pre_element');
 echo $this->element('Module/post', ['options' => $options]);
+echo $this->fetch('post_element');

--- a/src/Template/Module/index.ctp
+++ b/src/Template/Module/index.ctp
@@ -38,6 +38,9 @@ $urlExport = ['plugin' => $plugin, 'controller' => $controller, 'action' => 'exp
 
 $config = (new ModuleConfig(ConfigType::MODULE(), $controller))->parse();
 $title = isset($config->table->alias) ? $config->table->alias : Inflector::humanize(Inflector::underscore($controller));
+
+echo $this->fetch('pre_element');
+
 ?>
 <section class="content-header">
     <div class="row">
@@ -74,3 +77,5 @@ $title = isset($config->table->alias) ? $config->table->alias : Inflector::human
         </div>
     </div>
 </section>
+
+<?= echo $this->fetch('post_element'); ?>

--- a/src/Template/Module/index.ctp
+++ b/src/Template/Module/index.ctp
@@ -78,4 +78,4 @@ echo $this->fetch('pre_element');
     </div>
 </section>
 
-<?= echo $this->fetch('post_element'); ?>
+<?= $this->fetch('post_element'); ?>

--- a/src/Template/Module/view.ctp
+++ b/src/Template/Module/view.ctp
@@ -17,6 +17,7 @@ $options = [
     'fields' => $fields,
     'title' => null
 ];
-echo $this->element('Module/view', [
-    'options' => $options
-]);
+
+echo $this->fetch('pre_element');
+echo $this->element('Module/view', ['options' => $options]);
+echo $this->fetch('post_element');


### PR DESCRIPTION
In a specific module's view, in top or in the bottom (of add, edit, view, index) we can now load a custom block: JavaScript for complex validation, custom HTML, CSS, etc.

ie: 
If we add a new view in `Template/<MyModule>/add.ctp` will automatic load instead of the default one:

```
<?php
$this->extend('/Module/add');

$this->start('pre_element');
echo "<b>Top</b>";
$this->end();

$this->start('post_element');
echo "<b>Bottom</b>";
$this->end();
```