### PR TITLE
Remove maxLength for value (task #15310)

### DIFF
--- a/src/Model/Table/SettingsTable.php
+++ b/src/Model/Table/SettingsTable.php
@@ -67,7 +67,6 @@ class SettingsTable extends Table
 
         $validator
             ->scalar('value')
-            ->maxLength('value', 255)
             ->requirePresence('value', 'create')
             ->allowEmpty('value');
 


### PR DESCRIPTION
We remove the maxLength validations for Settings value since the value db type is `TEXT` now.