### PR TITLE
Fix backport (task #15519)

### DIFF
--- a/src/Controller/Component/CsvViewComponent.php
+++ b/src/Controller/Component/CsvViewComponent.php
@@ -121,7 +121,7 @@ class CsvViewComponent extends Component
      */
     protected function filterBatchFields(Event $event): void
     {
-        $config = new ModuleConfig(ConfigType::MIGRATION(), $this->getAction());
+        $config = new ModuleConfig(ConfigType::MIGRATION(), $this->request->getParam('controller'));
         $config = json_encode($config->parse());
         $fields = false === $config ? [] : json_decode($config, true);
 


### PR DESCRIPTION
This PR resolves the issue with batch form not filtering out unsupported fields (like files), by providing the correct module name for batch operation field filtering.