### PR TITLE
Remove link if user has no permission (task #15637)

### DIFF
--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -1,10 +1,12 @@
 <?php
 
+use App\View\AppView;
 use Cake\Core\Configure;
 
 // CsvMigrations plugin configuration
 return [
     'CsvMigrations' => [
+        'appView' => AppView::class,
         'tableValidation' => false,
         // Configuration options for the ValidateShell
         'ValidateShell' => [

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -46,6 +46,7 @@ class AppView extends View
         parent::initialize();
         $this->loadHelper('Menu.Menu');
         $this->loadHelper('Form', ['className' => 'AdminLTE.Form']);
+        $this->loadHelper('Html', ['className' => 'MyHtml']);
         $this->loadHelper('HtmlEmail');
         $this->loadHelper('Search');
         $this->loadHelper('SystemInfo');

--- a/src/View/Helper/MyHtmlHelper.php
+++ b/src/View/Helper/MyHtmlHelper.php
@@ -58,7 +58,7 @@ class MyHtmlHelper extends HtmlHelper
 
         $templater = $this->templater();
 
-        if ($rawUrl === '#') {
+        if (!is_array($rawUrl) && (filter_var($rawUrl, FILTER_VALIDATE_URL) || strpos((string)$rawUrl, '#') === 0)) {
             $rawUrl = [
                 'controller' => '',
                 'action' => '',

--- a/src/View/Helper/MyHtmlHelper.php
+++ b/src/View/Helper/MyHtmlHelper.php
@@ -1,0 +1,88 @@
+<?php
+namespace App\View\Helper;
+
+use Cake\Core\Configure;
+use Cake\Routing\Router;
+use Cake\View\Helper\HtmlHelper;
+use Qobo\Utils\Utility\User;
+use RolesCapabilities\Access\AccessFactory;
+
+class MyHtmlHelper extends HtmlHelper
+{
+    /**
+     * Creates an HTML link or a block, depending on user permissions.
+     *
+     * @param string|array $title The content to be wrapped by `<a>` tags.
+     *   Can be an array if $url is null. If $url is null, $title will be used as both the URL and title.
+     * @param string|array|null $url Cake-relative URL or array of URL parameters, or
+     *   external URL (starts with http://)
+     * @param array $options Array of options and HTML attributes.
+     * @return null|string An `<a />` or <div /> element.
+     * @link https://book.cakephp.org/3/en/views/helpers.html#aliasing-helpers
+     */
+    public function link($title, $url = null, array $options = [])
+    {
+        $rawUrl = $url;
+        $escapeTitle = true;
+        if ($url !== null) {
+            $url = $this->Url->build($url, $options);
+            unset($options['fullBase']);
+        } else {
+            $url = $this->Url->build($title);
+            $title = htmlspecialchars_decode($url, ENT_QUOTES);
+            $title = h(urldecode($title));
+            $escapeTitle = false;
+        }
+
+        if (isset($options['escapeTitle'])) {
+            $escapeTitle = $options['escapeTitle'];
+            unset($options['escapeTitle']);
+        } elseif (isset($options['escape'])) {
+            $escapeTitle = $options['escape'];
+        }
+
+        if ($escapeTitle === true) {
+            $title = h($title);
+        } elseif (is_string($escapeTitle)) {
+            $title = htmlentities($title, ENT_QUOTES, $escapeTitle);
+        }
+
+        $confirmMessage = null;
+        if (isset($options['confirm'])) {
+            $confirmMessage = $options['confirm'];
+            unset($options['confirm']);
+        }
+        if ($confirmMessage) {
+            $options['onclick'] = $this->_confirm($confirmMessage, 'return true;', 'return false;', $options);
+        }
+
+        $templater = $this->templater();
+
+        if ($rawUrl === '#') {
+            $rawUrl = [
+                'controller' => '',
+                'action' => '',
+            ];
+        }
+
+        if (!is_array($rawUrl)) {
+            $rawUrl = Router::getRouteCollection()->parse((string)$rawUrl);
+        }
+
+        $rawUrl['controller'] = !isset($rawUrl['controller']) ?: ucfirst($rawUrl['controller']);
+
+        $accessFactory = new AccessFactory();
+        $user = User::getCurrentUser();
+        if (empty($user) || $accessFactory->hasAccess($rawUrl, $user)) {
+            return $templater->format('link', [
+                'url' => $url,
+                'attrs' => $templater->formatAttributes($options),
+                'content' => $title,
+            ]);
+        }
+
+        return $templater->format('block', [
+           'content' => $title,
+        ]);
+    }
+}


### PR DESCRIPTION
Creates an HTML link or a block, depending on user permissions by aliasing the CakePHP HTML Helper and overwriting the `link()` method.

NB. this PR depends on [this](https://github.com/QoboLtd/cakephp-csv-migrations/pull/759).