### PR TITLE
Removing VueJS from phpcs indent checks (task #15719)

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,7 +37,7 @@
     <file>./webroot/</file>
 
     <!-- Ignore files -->
-    <arg name="ignore" value="config/Migrations/,webroot/dist/" />
+    <arg name="ignore" value="config/Migrations/,webroot/dist/, resources/" />
 
     <!-- Ignore minified files -->
     <exclude-pattern>*\.min\.(css|js)</exclude-pattern>


### PR DESCRIPTION
* Removing `resources/` directory from `phpcs` indent checks.

We have `.editorconfig` for correct indentation and `.eslintrc.js` for correct linting of JS code. 
All known IDEs have required support for both `eslint` and `editorconfig`.

