### PR TITLE
Fields helper render input updates (task #15480)

### DIFF
--- a/config/Modules/Things/config/fields.dist.json
+++ b/config/Modules/Things/config/fields.dist.json
@@ -3,7 +3,7 @@
         "label" : "label name",
         "personal" : true,
         "placeholder" : "The name",
-        "help" : "LONG TEST Help - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras cursus congue mi vitae semper. Proin vitae eros quis ipsum ornare sagittis efficitur ac odio. Vivamus iaculis, turpis in tempor hendrerit, neque mi dapibus sem, sed vulputate arcu nisi sed nibh. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla tempor condimentum quam. Quisque iaculis dui ac ipsum tempus semper. Vivamus interdum auctor dolor, sit amet pharetra est porta ac. Donec sit amet elit quam. Suspendisse imperdiet ullamcorper lacus, id convallis risus egestas vitae. Vestibulum aliquet tellus ut quam dapibus feugiat."
+        "help" : "LONG TEST Help - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras cursus congue mi vitae semper. Proin vitae eros quis ipsum ornare sagittis efficitur ac odio. Vivamus iaculis, turpis in tempor hendrerit, neque mi dapibus sem, sed vulputate arcu nisi sed nibh. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla tempor condimentum quam. Quisque iaculis dui ac ipsum tempus semper. Vivamus interdum auctor dolor, sit amet pharetra est porta ac. Donec sit amet elit quam."
     },
     "description" : {
         "label" : "label description",

--- a/config/Modules/Things/config/fields.dist.json
+++ b/config/Modules/Things/config/fields.dist.json
@@ -1,10 +1,91 @@
 {
     "name" : {
         "label" : "label name",
-        "personal" : true
+        "personal" : true,
+        "placeholder" : "The name",
+        "help" : "LONG TEST Help - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras cursus congue mi vitae semper. Proin vitae eros quis ipsum ornare sagittis efficitur ac odio. Vivamus iaculis, turpis in tempor hendrerit, neque mi dapibus sem, sed vulputate arcu nisi sed nibh. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla tempor condimentum quam. Quisque iaculis dui ac ipsum tempus semper. Vivamus interdum auctor dolor, sit amet pharetra est porta ac. Donec sit amet elit quam. Suspendisse imperdiet ullamcorper lacus, id convallis risus egestas vitae. Vestibulum aliquet tellus ut quam dapibus feugiat."
     },
     "description" : {
         "label" : "label description",
-        "translatable": true
+        "translatable": true,
+        "help" : "Help Description"
+    },
+    "appointment" : {
+        "help" : "Help Appointment"
+    },
+    "area" : {
+        "help" : "Help Area"
+    },
+    "assigned_to" : {
+        "help" : "Help Assigned To"
+    },
+    "bio" : {
+        "help" : "Help Bio"
+    },
+    "country" : {
+        "help" : "Help Country"
+    },
+    "currency" : {
+        "help" : "Help Currency"
+    },
+    "date_of_birth" : {
+        "help" : "Help Date Of Birth"
+    },
+    "email" : {
+        "help" : "Help Email"
+    },
+    "file" : {
+        "help" : "Help File"
+    },
+    "gender" : {
+        "help" : "Help Gender"
+    },
+    "language" : {
+        "help" : "Help Language"
+    },
+    "level" : {
+        "help" : "Help Level"
+    },
+    "non_searchable" : {
+        "help" : "Help Non Searchable"
+    },
+    "phone" : {
+        "help" : "Help Phone"
+    },
+    "photos" : {
+        "help" : "Help Photos"
+    },
+    "primary_thing" : {
+        "help" : "Help Primary Thing"
+    },
+    "rate" : {
+        "help" : "Help Rate"
+    },
+    "salary" : {
+        "help" : "Help Salary"
+    },
+    "sample_date" : {
+        "help" : "Help Sample Date"
+    },
+    "test_list" : {
+        "help" : "Help Test List"
+    },
+    "testmetric" : {
+        "help" : "Help Testmetric"
+    },
+    "testmoney" : {
+        "help" : "Help Testmoney"
+    },
+    "title" : {
+        "help" : "Help Title"
+    },
+    "vip" : {
+        "help" : "Help Vip"
+    },
+    "website" : {
+        "help" : "Help Website"
+    },
+    "work_start" : {
+        "help" : "Help Work Start"
     }
 }

--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -42,5 +42,11 @@ return [
                 ],
             ],
         ],
+        // Helper configuration : see App/View/Helper/MyHtmlHelper::class
+        'HelperConfig' => [
+            'dataToggle' => 'tooltip',
+            'classCss' => 'badge bg-blue',
+            'dataPlacement' => 'auto right',
+        ],
     ],
 ];

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -45,7 +45,7 @@ class AppView extends View
     {
         parent::initialize();
         $this->loadHelper('Menu.Menu');
-        $this->loadHelper('Form', ['className' => 'AdminLTE.Form']);
+        $this->loadHelper('Form', ['className' => 'MyForm']);
         $this->loadHelper('Html', ['className' => 'MyHtml']);
         $this->loadHelper('HtmlEmail');
         $this->loadHelper('Search');

--- a/src/View/Helper/MyFormHelper.php
+++ b/src/View/Helper/MyFormHelper.php
@@ -3,6 +3,7 @@
 namespace App\View\Helper;
 
 use AdminLTE\View\Helper\FormHelper;
+use App\View\Helper\MyHtmlHelper;
 use Cake\View\View;
 
 class MyFormHelper extends FormHelper
@@ -12,10 +13,12 @@ class MyFormHelper extends FormHelper
      */
     public function control($fieldName, array $options = [])
     {
+        $helper = new MyHtmlHelper(new View());
+
         if (!empty($options['help'])) {
             $options['templates'] = [
-                'label' => '<label class="control-label" {{attrs}}>{{text}}</label>
-                    <span class="help-tip"><p>' . $options['help'] . '</p></span>',
+                'label' => '<label class="control-label" {{attrs}}>{{text}}</label>' .
+                $helper->help($options['help']),
             ];
             unset($options['help']);
         }

--- a/src/View/Helper/MyFormHelper.php
+++ b/src/View/Helper/MyFormHelper.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\View\Helper;
+
+use AdminLTE\View\Helper\FormHelper;
+use Cake\View\View;
+
+class MyFormHelper extends FormHelper
+{
+    /**
+     * {@inheritDoc} \AdminLTE\View\Helper\FormHelper::control()
+     */
+    public function control($fieldName, array $options = [])
+    {
+        if (!empty($options['help'])) {
+            $options['templates'] = [
+                'label' => '<label class="control-label" {{attrs}}>{{text}}</label>
+                    <span class="help-tip"><p>' . $options['help'] . '</p></span>',
+            ];
+            unset($options['help']);
+        }
+
+        return parent::control($fieldName, $options);
+    }
+}

--- a/src/View/Helper/MyHtmlHelper.php
+++ b/src/View/Helper/MyHtmlHelper.php
@@ -17,7 +17,7 @@ class MyHtmlHelper extends HtmlHelper
      */
     public function help(string $message): string
     {
-        return '&nbsp;&nbsp;<span data-toggle="tooltip" title="" class="badge bg-yellow" data-placement="auto right" data-original-title="' . __($message) . '">?</span>';
+        return '&nbsp;&nbsp;<span data-toggle="tooltip" title="" class="badge bg-blue" data-placement="auto right" data-original-title="' . __($message) . '">?</span>';
     }
 
     /**

--- a/src/View/Helper/MyHtmlHelper.php
+++ b/src/View/Helper/MyHtmlHelper.php
@@ -17,7 +17,11 @@ class MyHtmlHelper extends HtmlHelper
      */
     public function help(string $message): string
     {
-        return '&nbsp;&nbsp;<span data-toggle="tooltip" title="" class="badge bg-blue" data-placement="auto right" data-original-title="' . __($message) . '">?</span>';
+        $dataToggle = Configure::read("CsvMigrations.HelperConfig.dataToggle");
+        $classCss = Configure::read("CsvMigrations.HelperConfig.classCss");
+        $dataPlacement = Configure::read("CsvMigrations.HelperConfig.dataPlacement");
+
+        return '&nbsp;&nbsp;<span data-toggle="' . $dataToggle . '" class="' . $classCss . '" data-placement="' . $dataPlacement . '" data-original-title="' . __($message) . '">?</span>';
     }
 
     /**

--- a/src/View/Helper/MyHtmlHelper.php
+++ b/src/View/Helper/MyHtmlHelper.php
@@ -10,6 +10,17 @@ use RolesCapabilities\Access\AccessFactory;
 class MyHtmlHelper extends HtmlHelper
 {
     /**
+     * Template for help tooltip
+     *
+     * @param string $message Help message
+     * @return string
+     */
+    public function help(string $message): string
+    {
+        return '&nbsp;&nbsp;<span data-toggle="tooltip" title="" class="badge bg-yellow" data-placement="auto right" data-original-title="' . __($message) . '">?</span>';
+    }
+
+    /**
      * Creates an HTML link or a block, depending on user permissions.
      *
      * @param string|array $title The content to be wrapped by `<a>` tags.

--- a/webroot/css/custom.css
+++ b/webroot/css/custom.css
@@ -134,3 +134,7 @@ hr.separator {
     background: #00a65a;
     border-color: #008d4c;
 }
+
+.tooltip-inner {
+    text-align: left;
+}


### PR DESCRIPTION
Implement a help tooltip for the input fields of the modules.  
The helper text can be saved in the field.json file of the module.
![image](https://user-images.githubusercontent.com/40852083/78011667-8be57180-734c-11ea-81ea-8432c00998b3.png)

