### PR TITLE
Replacing lodash full lib with debounce method import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10607,6 +10607,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
       "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "flag-icon-css": "^3.4.6",
     "icheck": "^1.0.2",
     "inflected": "^2.0.4",
+    "lodash.debounce": "^4.0.8",
     "node-sass": "^4.13.1",
     "rrule": "^2.6.4",
     "sass-loader": "^7.3.1",

--- a/resources/src/components/fh/Related.vue
+++ b/resources/src/components/fh/Related.vue
@@ -23,7 +23,7 @@
 
 <script>
 import axios from 'axios'
-import lodash from 'lodash'
+import debounce from 'lodash.debounce'
 import vSelect from 'vue-select'
 import { MAGIC_VALUE_WRAPPER } from '@/utils/constants.js'
 import UuidMixin from '@/mixins/uuid.js'
@@ -131,7 +131,7 @@ export default {
             this.options = []
             this.search(search, loading, this)
         },
-        search: _.debounce((search, loading, vm, page = 1) => {
+        search: debounce((search, loading, vm, page = 1) => {
             axios({
                 method: 'get',
                 url: encodeURI('/api/' + vm.source + '/lookup?query=' + search + '&limit=100&page=' + page),


### PR DESCRIPTION
* Replacing `lodash` with `lodash.debouce` library to minimise final `app.js` size