### PR TITLE
Adding required property present in the response

### DIFF
--- a/src/Crud/Action/SchemaAction.php
+++ b/src/Crud/Action/SchemaAction.php
@@ -69,10 +69,10 @@ class SchemaAction extends BaseAction
             $data = [
                 'name' => $csvField->getName(),
                 'type' => $csvField->getType(),
+                'required' => $csvField->getRequired(),
             ];
             // Check if exist a label, or required, non_searchable, unique are set as true.
             !empty($fieldJson[$csvField->getName()]['label']) ? $data['label'] = $fieldJson[$csvField->getName()]['label'] : '';
-            $csvField->getRequired() ? $data['required'] = true : '';
             $csvField->getNonSearchable() ? $data['non_searchable'] = true : '';
             $csvField->getUnique() ? $data['unique'] = true : '';
 


### PR DESCRIPTION
* Adding `required` property from `migration.json` into API response payload. 

It should minimize some of the frontend checks on data struct field consistency.
