### PR TITLE
Prevent show help tooltips on empty message (task #15480)

### DIFF
--- a/config/Modules/Things/config/fields.dist.json
+++ b/config/Modules/Things/config/fields.dist.json
@@ -2,13 +2,12 @@
     "name" : {
         "label" : "label name",
         "personal" : true,
-        "placeholder" : "The name",
-        "help" : "LONG TEST Help - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras cursus congue mi vitae semper. Proin vitae eros quis ipsum ornare sagittis efficitur ac odio. Vivamus iaculis, turpis in tempor hendrerit, neque mi dapibus sem, sed vulputate arcu nisi sed nibh. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla tempor condimentum quam. Quisque iaculis dui ac ipsum tempus semper. Vivamus interdum auctor dolor, sit amet pharetra est porta ac. Donec sit amet elit quam."
+        "placeholder" : "The name - without help tooltip"
     },
     "description" : {
         "label" : "label description",
         "translatable": true,
-        "help" : "Help Description"
+        "help" : "LONG TEST Help - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras cursus congue mi vitae semper. Proin vitae eros quis ipsum ornare sagittis efficitur ac odio. Vivamus iaculis, turpis in tempor hendrerit, neque mi dapibus sem, sed vulputate arcu nisi sed nibh. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla tempor condimentum quam. Quisque iaculis dui ac ipsum tempus semper. Vivamus interdum auctor dolor, sit amet pharetra est porta ac. Donec sit amet elit quam."
     },
     "appointment" : {
         "help" : "Help Appointment"

--- a/config/csv_migrations.php
+++ b/config/csv_migrations.php
@@ -45,7 +45,7 @@ return [
         // Helper configuration : see App/View/Helper/MyHtmlHelper::class
         'HelperConfig' => [
             'dataToggle' => 'tooltip',
-            'classCss' => 'badge bg-blue',
+            'classCss' => 'badgeLeft badge bg-blue',
             'dataPlacement' => 'auto right',
         ],
     ],

--- a/src/View/Helper/MyHtmlHelper.php
+++ b/src/View/Helper/MyHtmlHelper.php
@@ -21,7 +21,7 @@ class MyHtmlHelper extends HtmlHelper
         $classCss = Configure::read("CsvMigrations.HelperConfig.classCss");
         $dataPlacement = Configure::read("CsvMigrations.HelperConfig.dataPlacement");
 
-        return empty($message) ? '' : '&nbsp;&nbsp;<span data-toggle="' . $dataToggle . '" class="' . $classCss . '" data-placement="' . $dataPlacement . '" data-original-title="' . __($message) . '">?</span>';
+        return empty($message) ? '' : '<span data-toggle="' . $dataToggle . '" class="' . $classCss . '" data-placement="' . $dataPlacement . '" data-original-title="' . __($message) . '">?</span>';
     }
 
     /**

--- a/src/View/Helper/MyHtmlHelper.php
+++ b/src/View/Helper/MyHtmlHelper.php
@@ -21,7 +21,7 @@ class MyHtmlHelper extends HtmlHelper
         $classCss = Configure::read("CsvMigrations.HelperConfig.classCss");
         $dataPlacement = Configure::read("CsvMigrations.HelperConfig.dataPlacement");
 
-        return '&nbsp;&nbsp;<span data-toggle="' . $dataToggle . '" class="' . $classCss . '" data-placement="' . $dataPlacement . '" data-original-title="' . __($message) . '">?</span>';
+        return empty($message) ? '' : '&nbsp;&nbsp;<span data-toggle="' . $dataToggle . '" class="' . $classCss . '" data-placement="' . $dataPlacement . '" data-original-title="' . __($message) . '">?</span>';
     }
 
     /**

--- a/webroot/css/custom.css
+++ b/webroot/css/custom.css
@@ -138,3 +138,7 @@ hr.separator {
 .tooltip-inner {
     text-align: left;
 }
+
+.badgeLeft {
+    margin-left: 0.7em;
+}


### PR DESCRIPTION
Small bugfix on help tooltip : few csv migration field are not passing the help value to the template causing show the question mark icons without any text.