### PR TITLE
Improve thumbnails in data tables (task #15955)

### DIFF
--- a/webroot/css/custom.css
+++ b/webroot/css/custom.css
@@ -142,3 +142,21 @@ hr.separator {
 .badgeLeft {
     margin-left: 0.7em;
 }
+
+/** Improve support for thumbnails in data tables **/
+table.dataTable .caption,
+table.dataTable .thumbnail-controls,
+table.dataTable .thumbnail {
+    display: none;
+}
+table.dataTable .row .thumbnail-0 {
+    width: 100%;
+}
+table.dataTable .row .thumbnail-0 .thumbnail {
+    display: table-cell;
+    border: none;
+}
+table.dataTable .row .thumbnail-0 img {
+    margin: 0;
+    display: inline !important;
+}


### PR DESCRIPTION
Display only one image in datatables with no controls to avoid breaking the datatable.

PR depends on https://github.com/QoboLtd/cakephp-csv-migrations/pull/781