### PR TITLE
limiting the saved searches to the model you're in [port] (task #16554)

### DIFF
--- a/resources/src/components/Search/SavedSearchSelector.vue
+++ b/resources/src/components/Search/SavedSearchSelector.vue
@@ -15,7 +15,7 @@
           -- Please choose --
         </option>
         <option
-          v-for="(item, searchIndex) in savedSearches"
+          v-for="(item, searchIndex) in moduleSavedSearches"
           :key="searchIndex"
           :value="item.id"
         >
@@ -65,8 +65,17 @@ export default {
     ...mapState({
       savedSearches: state => state.search.savedSearches,
       searchId: state => state.search.id,
-      userId: state => state.search.user_id
-    })
+      userId: state => state.search.user_id,
+      currentModel: state => state.search.model
+    }),
+    moduleSavedSearches () {
+      let result = []
+      if (this.savedSearches.length) {
+        result = this.savedSearches.filter(item => item.model == this.currentModel)
+      }
+
+      return result
+    }
   },
   created () {
     this.$store.dispatch('search/savedSearchesGet')


### PR DESCRIPTION
Make sure when we're in `/<module>/search` page, we display the saved searches related to currently viewed Module.