### PR TITLE
Split multiline command to arguments (task #11513)

### DIFF
--- a/src/ScheduledJobs/Jobs/CakeShellJob.php
+++ b/src/ScheduledJobs/Jobs/CakeShellJob.php
@@ -48,7 +48,9 @@ class CakeShellJob extends AbstractShellJob
             $command = array_merge($command, $parts);
         }
 
-        if (!empty($this->arguments)) {
+        if (is_array($this->arguments)) {
+            $command = array_merge($command, $this->arguments);
+        } elseif (!empty($this->arguments)) {
             array_push($command, $this->arguments);
         }
 

--- a/src/Shell/CronShell.php
+++ b/src/Shell/CronShell.php
@@ -113,7 +113,8 @@ class CronShell extends Shell
             try {
                 $this->info("Starting Scheduled Task [{$entity->get('name')}]");
                 $lock = $this->lock(__FILE__, $entity->get('job'));
-                $state = $instance->run($entity->get('options'));
+                $options = (array)preg_split("/\r\n|\n|\r/", $entity->get('options'));
+                $state = $instance->run($options);
                 $this->info("Finished Scheduled Task [{$entity->get('name')}]");
                 $this->verbose("Scheduled Task [" . $entity->get('name') . "] finished with: " . print_r($state, true));
                 if ($state['state'] > 0) {


### PR DESCRIPTION
We split multiline commands to arguments so that we comply with Symfony Process implementation.

