### PR TITLE
Lookup method does not return correct results (Task #17074)

### DIFF
--- a/src/Event/Controller/Api/LookupActionListener.php
+++ b/src/Event/Controller/Api/LookupActionListener.php
@@ -259,6 +259,10 @@ class LookupActionListener extends BaseActionListener
         $config = ModuleRegistry::getModule($table->getRegistryAlias())->getConfig();
         $fields = Hash::get($config, 'table.typeahead_fields', [$table->getDisplayField()]);
 
+        if (empty($fields)) {
+            $fields = [$table->getDisplayField()];
+        }
+
         // Extract the virtual fields to actual db fields before asking for an alias
         $fields = $this->extractVirtualFields($table, $fields);
         foreach ($fields as $k => $v) {

--- a/src/Event/Controller/Api/LookupActionListener.php
+++ b/src/Event/Controller/Api/LookupActionListener.php
@@ -257,7 +257,7 @@ class LookupActionListener extends BaseActionListener
     protected function _getTypeaheadFields(Table $table): array
     {
         $config = ModuleRegistry::getModule($table->getRegistryAlias())->getConfig();
-        $fields = Hash::get($config, 'table.typeahead_fields', [$table->getDisplayField()]);
+        $fields = Hash::get($config, 'table.typeahead_fields');
 
         if (empty($fields)) {
             $fields = [$table->getDisplayField()];

--- a/tests/TestCase/Event/LookupActionListenerTest.php
+++ b/tests/TestCase/Event/LookupActionListenerTest.php
@@ -14,8 +14,11 @@ class LookupActionListenerTest extends TestCase
 {
     private $Users;
 
+    private $Things;
+
     public $fixtures = [
         'app.Users',
+        'app.Things',
         'plugin.Groups.Groups',
         'plugin.Groups.GroupsUsers',
     ];
@@ -25,6 +28,7 @@ class LookupActionListenerTest extends TestCase
         parent::setUp();
 
         $this->Users = TableRegistry::getTableLocator()->get('Users');
+        $this->Things = TableRegistry::getTableLocator()->get('Things');
     }
 
     public function testBeforeLookupEmptyQuery(): void
@@ -39,6 +43,20 @@ class LookupActionListenerTest extends TestCase
         $listener = new LookupActionListener();
         $listener->beforeLookup($event, $query);
         $this->assertFalse($query->isEmpty());
+    }
+
+    public function testBeforeLookupTypeAheadFields(): void
+    {
+        $query = $this->Things->find('all');
+        $controller = new Controller($this->getRequest(['query' => 'Thing #']), null, 'Things');
+        $event = new Event(
+            (string)EventName::API_LOOKUP_BEFORE_FIND(),
+            $controller
+        );
+
+        $listener = new LookupActionListener();
+        $listener->beforeLookup($event, $query);
+        $this->assertEquals(2, $query->count());
     }
 
     public function testBeforeLookupWithQuery(): void


### PR DESCRIPTION
This PR fixes an issue where fallback to display_field didn't work in case the typeahead_fields in the table config were empty