### PR TITLE
Fix integer on Settings index page (task #15054)

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -57,7 +57,7 @@ return [
                     ],
                     'Port' => [
                         'alias' => 'EmailTransport.default.port',
-                        'type' => 'string',
+                        'type' => 'integer',
                         'help' => '',
                         'scope' => [
                             'app',

--- a/config/settings.php
+++ b/config/settings.php
@@ -141,7 +141,7 @@ return [
                     ],
                     'Version' => [
                         'alias' => 'Ldap.version',
-                        'type' => 'string',
+                        'type' => 'integer',
                         'help' => '',
                         'scope' => [
                             'app',

--- a/src/Template/Settings/index.ctp
+++ b/src/Template/Settings/index.ctp
@@ -148,9 +148,9 @@ $(document).ready(function(){
                                                 'fieldDefinitions' => $definition,
                                                 'label' => $field
                                             ];
-                                            if (json_decode($value) && json_last_error() === JSON_ERROR_NONE) {
-                                                $fieldDefinition['attributes'] = ['readonly' => true];
-                                            }
+											if (!is_integer($value) && json_decode($value) && json_last_error() !== JSON_ERROR_NONE) {
+												$fieldDefinition['attributes'] = ['readonly' => true];
+											}
                                             if ($fieldValue['type'] === 'list' && !empty($fieldValue['selectOptions'])) {
                                                 $fieldDefinition['selectOptions'] = $fieldValue['selectOptions'];
                                             }


### PR DESCRIPTION
Numbers in PHP apparently are valid JSON values and it breaks the Settings
![image](https://user-images.githubusercontent.com/40852083/88273926-9785eb00-cce3-11ea-88ec-1dc6f46eceac.png)
