### PR TITLE
Logs screen broken rendering

### DIFF
--- a/src/Event/Plugin/DatabaseLog/Model/ExtendDatabaseLogsSelectClauseListener.php
+++ b/src/Event/Plugin/DatabaseLog/Model/ExtendDatabaseLogsSelectClauseListener.php
@@ -20,7 +20,7 @@ final class ExtendDatabaseLogsSelectClauseListener implements EventListenerInter
     /** {@inheritDoc} */
     public function extendSelectClause(Event $event, Query $query, \ArrayObject $options, bool $primary): void
     {
-        if ($primary && $query->repository() instanceof DatabaseLogsTable) {
+        if ($primary && $query->getRepository() instanceof DatabaseLogsTable) {
             $query->select(['context', 'hostname', 'ip', 'message', 'refer', 'uri']);
         }
     }

--- a/src/Event/Plugin/DatabaseLog/Model/ExtendDatabaseLogsSelectClauseListener.php
+++ b/src/Event/Plugin/DatabaseLog/Model/ExtendDatabaseLogsSelectClauseListener.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\Plugin\DatabaseLog\Model;
+
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\ORM\Query;
+use DatabaseLog\Model\Table\DatabaseLogsTable;
+
+final class ExtendDatabaseLogsSelectClauseListener implements EventListenerInterface
+{
+    /** {@inheritDoc} */
+    public function implementedEvents()
+    {
+        return ['Model.beforeFind' => 'extendSelectClause'];
+    }
+
+    /** {@inheritDoc} */
+    public function extendSelectClause(Event $event, Query $query, \ArrayObject $options, bool $primary): void
+    {
+        if ($primary && $query->repository() instanceof DatabaseLogsTable) {
+            $query->select(['context', 'hostname', 'ip', 'message', 'refer', 'uri']);
+        }
+    }
+}

--- a/src/Template/Element/Log/message.ctp
+++ b/src/Template/Element/Log/message.ctp
@@ -25,6 +25,10 @@ $log = array_merge($defaultLog, $log->toArray());
         <div class="col-md-2 text-right"><strong><?= __('Referrer'); ?></strong></div>
         <div class="col-md-10"><?= h($log['refer']); ?></div>
     </div>
+    <div class="row">
+        <div class="col-md-2 text-right"><strong><?= __('Summary'); ?></strong></div>
+        <div class="col-md-10"><?= trim(h($log['summary'])); ?></div>
+    </div>
     <div class="row" style="margin-top:20px;">
         <div class="col-md-2 text-right"><strong><?= __('Message'); ?></strong></div>
         <div class="col-md-10"><pre><small><?= trim(h($log['message'])); ?></small></pre></div>

--- a/src/Template/Logs/index.ctp
+++ b/src/Template/Logs/index.ctp
@@ -76,7 +76,6 @@ $age = Configure::read('DatabaseLog.maxLength');
                         }
                         ?>
                     </div>
-                    <?= $this->element('DatabaseLog.admin_filter'); ?>
                 </div>
             </div>
 

--- a/tests/TestCase/Event/Plugin/DatabaseLog/Model/ExtendDatabaseLogsSelectClauseListenerTest.php
+++ b/tests/TestCase/Event/Plugin/DatabaseLog/Model/ExtendDatabaseLogsSelectClauseListenerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Event\Plugin\DatabaseLog\Model;
+
+use App\Event\Plugin\DatabaseLog\Model\ExtendDatabaseLogsSelectClauseListener;
+use Cake\Event\Event;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ExtendDatabaseLogsSelectClauseListenerTest extends TestCase
+{
+    public $fixtures = [
+        'app.Things',
+        'plugin.DatabaseLog.DatabaseLogs',
+    ];
+
+    public function testImplementedEvents(): void
+    {
+        $this->assertSame(
+            ['Model.beforeFind' => 'extendSelectClause'],
+            (new ExtendDatabaseLogsSelectClauseListener())->implementedEvents()
+        );
+    }
+
+    public function testExtendSelectClauseWithDatabaseLogsQueryAsPrimary(): void
+    {
+        $repository = TableRegistry::getTableLocator()->get('Logs');
+
+        $query = $repository->find()->select('id');
+
+        $expected = ['id'];
+        $this->assertSame($expected, $query->clause('select'));
+
+        (new ExtendDatabaseLogsSelectClauseListener())
+            ->extendSelectClause(new Event(''), $query, new \ArrayObject(), true);
+
+        $expected = ['id', 'context', 'hostname', 'ip', 'message', 'refer', 'uri'];
+        $this->assertSame($expected, $query->clause('select'));
+    }
+
+    public function testExtendSelectClauseWithDatabaseLogsQueryAsNonPrimary(): void
+    {
+        $repository = TableRegistry::getTableLocator()->get('Logs');
+
+        $query = $repository->find()->select('id');
+
+        $expected = ['id'];
+        $this->assertSame($expected, $query->clause('select'));
+
+        (new ExtendDatabaseLogsSelectClauseListener())
+            ->extendSelectClause(new Event(''), $query, new \ArrayObject(), false);
+
+        $this->assertSame($expected, $query->clause('select'));
+    }
+
+    public function testExtendSelectClauseWithNonDatabaseLogsQuery(): void
+    {
+        $repository = TableRegistry::getTableLocator()->get('Things');
+
+        $query = $repository->find()->select('id');
+
+        $expected = ['id'];
+        $this->assertSame($expected, $query->clause('select'));
+
+        (new ExtendDatabaseLogsSelectClauseListener())
+            ->extendSelectClause(new Event(''), $query, new \ArrayObject(), true);
+
+        $this->assertSame($expected, $query->clause('select'));
+    }
+}


### PR DESCRIPTION
This PR fixes the broken Logs index screen.

The main cause of the issue was the loading of an element that has been removed by the upstream vendor.

Additionally, once the aforementioned issue was fixed, the rendered logs were missing a lot of information. This was caused by the limited select-clause applied by the upstream vendor [here](https://github.com/dereuromark/CakePHP-DatabaseLog/commit/230954e9f51ea9e0a0bd209beafd01c5026f9c16#diff-02426bf2e25d6e70c029a545abcc6322R83).